### PR TITLE
Bump google-webrtc version to 1.0.32006

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     }
 
     implementation 'org.osgi:org.osgi.framework:1.9.0'
-    implementation 'org.webrtc:google-webrtc:1.0.28513'
+    implementation 'org.webrtc:google-webrtc:1.0.32006'
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'


### PR DESCRIPTION
*Issue #, if available:* #80

*Description of changes:* Upgrade google-webrtc to the latest version. More information is available in the issue #80.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
