### PR TITLE
WebRTC Ingestion Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ local.properties
 .gradle/
 *.iml
 .idea/
+*awsconfiguration.json

--- a/build.gradle
+++ b/build.gradle
@@ -116,11 +116,11 @@ dependencies {
     implementation 'com.github.tony19:logback-android:2.0.0'
     implementation 'commons-codec:commons-codec:1.9'
 
-    minSdk24Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.12') {
+    minSdk24Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.20') {
         exclude module: 'javax.inject'
     }
 
-    minSdk28Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.15') {
+    minSdk28Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.20') {
         exclude module: 'javax.inject'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ android {
         targetSdkVersion 29
         applicationId "com.amazonaws.kinesisvideo.webrtc.demoapp"
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -96,11 +96,12 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
 
-    def aws_version = '2.16.5'
+    def aws_version = '2.68.0'
     implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
-    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo-signaling:$aws_version@jar") { transitive = true }
+    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo-signaling:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
+    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo-webrtcstorage:$aws_version@aar") { transitive = true }
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,17 +14,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'jacoco-android'
 
 jacoco {
-  toolVersion = "0.8.4"
+    toolVersion = "0.8.4"
 }
 
 tasks.withType(Test) {
-  jacoco.includeNoLocationClasses = true
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 jacocoAndroidUnitTestReport {
-  csv.enabled false
-  html.enabled true
-  xml.enabled false
+    csv.enabled false
+    html.enabled true
+    xml.enabled false
 }
 
 android {
@@ -95,13 +96,14 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+    implementation 'junit:junit:4.12'
 
     def aws_version = '2.68.0'
-    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
-    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo-signaling:$aws_version@aar") { transitive = true }
-    implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }
-    implementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
-    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo-webrtcstorage:$aws_version@aar") { transitive = true }
+    implementation("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
+    implementation("com.amazonaws:aws-android-sdk-kinesisvideo-signaling:$aws_version@aar") { transitive = true }
+    implementation("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }
+    implementation("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
+    implementation("com.amazonaws:aws-android-sdk-kinesisvideo-webrtcstorage:$aws_version@aar") { transitive = true }
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
@@ -114,12 +116,12 @@ dependencies {
     implementation 'com.github.tony19:logback-android:2.0.0'
     implementation 'commons-codec:commons-codec:1.9'
 
-    minSdk24Implementation ('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.12'){
-        exclude module : 'javax.inject'
+    minSdk24Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.12') {
+        exclude module: 'javax.inject'
     }
 
-    minSdk28Implementation ('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.15'){
-        exclude module : 'javax.inject'
+    minSdk28Implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.15') {
+        exclude module: 'javax.inject'
     }
 
     implementation 'org.osgi:org.osgi.framework:1.9.0'

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoWebRtcDemoApp.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoWebRtcDemoApp.java
@@ -27,13 +27,24 @@ public class KinesisVideoWebRtcDemoApp extends Application {
         return AWSMobileClient.getInstance();
     }
 
+    /**
+     * Parse awsconfiguration.json and extract the region from it.
+     *
+     * @return The region in String form. {@code null} if not.
+     * @throws IllegalStateException if awsconfiguration.json is not properly configured.
+     */
     public static String getRegion() {
-        AWSConfiguration configuration = AWSMobileClient.getInstance().getConfiguration();
-        JSONObject jsonObject = configuration.optJsonObject("CredentialsProvider");
+        final AWSConfiguration configuration = AWSMobileClient.getInstance().getConfiguration();
+        if (configuration == null) {
+            throw new IllegalStateException("awsconfiguration.json has not been properly configured!");
+        }
+
+        final JSONObject jsonObject = configuration.optJsonObject("CredentialsProvider");
+
         String region = null;
         try {
             region = (String) ((JSONObject) (((JSONObject) jsonObject.get("CognitoIdentity")).get("Default"))).get("Region");
-        } catch (JSONException e) {
+        } catch (final JSONException e) {
             Log.e(TAG, "Got exception when extracting region from cognito setting.", e);
         }
         return region;

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/SimpleNavActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/SimpleNavActivity.java
@@ -1,9 +1,12 @@
 package com.amazonaws.kinesisvideo.demoapp.activity;
 
+import android.app.Activity;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
@@ -21,6 +24,8 @@ import com.amazonaws.mobile.client.SignInUIOptions;
 import com.amazonaws.mobile.client.UserStateDetails;
 import com.google.android.material.navigation.NavigationView;
 
+import java.util.Optional;
+
 @SuppressWarnings("WeakerAccess")
 public class SimpleNavActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
@@ -32,6 +37,7 @@ public class SimpleNavActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         setContentView(R.layout.activity_simple_nav);
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/StartUpActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/StartUpActivity.java
@@ -1,19 +1,25 @@
 package com.amazonaws.kinesisvideo.demoapp.activity;
 
+import android.app.Activity;
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
 import com.amazonaws.kinesisvideo.demoapp.R;
 import com.amazonaws.kinesisvideo.demoapp.util.ActivityUtils;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.client.Callback;
 import com.amazonaws.mobile.client.SignInUIOptions;
 import com.amazonaws.mobile.client.UserStateDetails;
+
+import java.util.Optional;
 
 public class StartUpActivity extends AppCompatActivity {
     private static final String TAG = StartUpActivity.class.getSimpleName();

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -275,8 +275,10 @@ public class WebRtcActivity extends AppCompatActivity {
                 client = new SignalingServiceWebSocketClient(wsHost, signalingListener, Executors.newFixedThreadPool(10));
 
                 Log.d(TAG, "Client connection " + (client.isOpen() ? "Successful" : "Failed"));
-            } catch (Exception e) {
+            } catch (final Exception e) {
+                Log.e(TAG, "Exception with websocket client: " + e);
                 gotException = true;
+                return;
             }
 
             if (isValidClient()) {
@@ -289,7 +291,6 @@ public class WebRtcActivity extends AppCompatActivity {
                     if (webrtcEndpoint != null) {
                         new Thread(() -> {
                             try {
-                                Thread.sleep(4500);
                                 final AWSKinesisVideoWebRTCStorageClient storageClient =
                                         new AWSKinesisVideoWebRTCStorageClient(
                                                 KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
@@ -528,10 +529,10 @@ public class WebRtcActivity extends AppCompatActivity {
                         .setVideoDecoderFactory(vdf)
                         .setVideoEncoderFactory(vef)
                         .setAudioDeviceModule(JavaAudioDeviceModule.builder(getApplicationContext())
-                                .setSampleRate(16000)
                                 .createAudioDeviceModule())
                         .createPeerConnectionFactory();
 
+        // Enable Google WebRTC debug logs
         Logging.enableLogToDebugOutput(Logging.Severity.LS_INFO);
 
         videoCapturer = createVideoCapturer();
@@ -781,7 +782,7 @@ public class WebRtcActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onMessage(DataChannel.Buffer buffer) {
+            public void onMessage(final DataChannel.Buffer buffer) {
                 // Send out data, no op on sender side
             }
         });
@@ -834,7 +835,7 @@ public class WebRtcActivity extends AppCompatActivity {
     // when local is set to be the master
     private void createSdpAnswer() {
 
-        MediaConstraints sdpMediaConstraints = new MediaConstraints();
+        final MediaConstraints sdpMediaConstraints = new MediaConstraints();
 
         sdpMediaConstraints.mandatory.add(new MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"));
         sdpMediaConstraints.mandatory.add(new MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"));
@@ -857,6 +858,7 @@ public class WebRtcActivity extends AppCompatActivity {
             public void onCreateFailure(final String error) {
                 super.onCreateFailure(error);
 
+                // Some emulators are missing H.264 support.
                 if (error.contains("ERROR_CONTENT")) {
                     Log.e(TAG, "Device missing H.264 support!");
                 }
@@ -909,7 +911,7 @@ public class WebRtcActivity extends AppCompatActivity {
 
     @SuppressLint("ClickableViewAccessibility")
     private void resizeLocalView() {
-        DisplayMetrics displayMetrics = new DisplayMetrics();
+        final DisplayMetrics displayMetrics = new DisplayMetrics();
         final ViewGroup.LayoutParams lp = localView.getLayoutParams();
         getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
         lp.height = (int) (displayMetrics.heightPixels * 0.25);
@@ -964,7 +966,7 @@ public class WebRtcActivity extends AppCompatActivity {
 
     private void resizeRemoteView() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            DisplayMetrics displayMetrics = new DisplayMetrics();
+            final DisplayMetrics displayMetrics = new DisplayMetrics();
             final ViewGroup.LayoutParams lp = remoteView.getLayoutParams();
             getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
             lp.height = (int) (displayMetrics.heightPixels * 0.75);
@@ -978,14 +980,14 @@ public class WebRtcActivity extends AppCompatActivity {
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            CharSequence name = getString(R.string.data_channel_notification);
-            String description = getString(R.string.data_channel_notification_description);
-            int importance = NotificationManager.IMPORTANCE_HIGH;
-            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            final CharSequence name = getString(R.string.data_channel_notification);
+            final String description = getString(R.string.data_channel_notification_description);
+            final int importance = NotificationManager.IMPORTANCE_HIGH;
+            final NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
             channel.setDescription(description);
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
-            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            final NotificationManager notificationManager = getSystemService(NotificationManager.class);
             notificationManager.createNotificationChannel(channel);
         }
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -49,6 +49,7 @@ import com.amazonaws.kinesisvideo.signaling.model.Event;
 import com.amazonaws.kinesisvideo.signaling.model.Message;
 import com.amazonaws.kinesisvideo.signaling.tyrus.SignalingServiceWebSocketClient;
 import com.amazonaws.kinesisvideo.utils.AwsV4Signer;
+import com.amazonaws.kinesisvideo.utils.Constants;
 import com.amazonaws.kinesisvideo.webrtc.KinesisVideoPeerConnection;
 import com.amazonaws.kinesisvideo.webrtc.KinesisVideoSdpObserver;
 import com.amazonaws.regions.Region;
@@ -179,10 +180,10 @@ public class WebRtcActivity extends AppCompatActivity {
     private void initWsConnection() {
 
         // See https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-2.html
-        final String masterEndpoint = mWssEndpoint + "?X-Amz-ChannelARN=" + mChannelArn;
+        final String masterEndpoint = mWssEndpoint + "?" + Constants.CHANNEL_ARN_QUERY_PARAM + "=" + mChannelArn;
 
         // See https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-1.html
-        final String viewerEndpoint = mWssEndpoint + "?X-Amz-ChannelARN=" + mChannelArn + "&X-Amz-ClientId=" + mClientId;
+        final String viewerEndpoint = mWssEndpoint + "?" + Constants.CHANNEL_ARN_QUERY_PARAM + "=" + mChannelArn + "&" + Constants.CLIENT_ID_QUERY_PARAM+ "=" + mClientId;
 
         runOnUiThread(() -> mCreds = KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
 

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -200,6 +200,7 @@ public class WebRtcActivity extends AppCompatActivity {
         final String wsHost = signedUri.toString();
 
         // Step 10. Create Signaling Client Event Listeners.
+        //          When we receive messages, we need to take the appropriate action.
         final SignalingListener signalingListener = new SignalingListener() {
 
             @Override

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -858,9 +858,9 @@ public class WebRtcActivity extends AppCompatActivity {
             public void onCreateFailure(final String error) {
                 super.onCreateFailure(error);
 
-                // Some emulators are missing H.264 support.
+                // Device is unable to support the requested media format
                 if (error.contains("ERROR_CONTENT")) {
-                    Log.e(TAG, "Device missing H.264 support!");
+                    Log.e(TAG, "No supported codec is present in the offer!");
                 }
                 gotException = true;
             }

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -243,7 +243,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
             ArrayList<String> passwords = new ArrayList<>(mIceServerList.size());
             ArrayList<Integer> ttls = new ArrayList<>(mIceServerList.size());
             ArrayList<List<String>> urisList = new ArrayList<>();
-            for (IceServer iceServer : mIceServerList) {
+            for (final IceServer iceServer : mIceServerList) {
                 userNames.add(iceServer.getUsername());
                 passwords.add(iceServer.getPassword());
                 ttls.add(iceServer.getTtl());
@@ -421,6 +421,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
                 final AWSKinesisVideoSignalingClient awsKinesisVideoSignalingClient = mFragment.get().getAwsKinesisVideoSignalingClient(region, dataEndpoint);
                 GetIceServerConfigResult getIceServerConfigResult = awsKinesisVideoSignalingClient.getIceServerConfig(
                         new GetIceServerConfigRequest().withChannelARN(mFragment.get().mChannelArn).withClientId(role.name()));
+                System.err.println("OOOOOO " + getIceServerConfigResult.getIceServerList());
                 mFragment.get().mIceServerList.addAll(getIceServerConfigResult.getIceServerList());
             } catch (Exception e) {
                 return "Get Ice Server Config failed with Exception " + e.getLocalizedMessage();

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -421,7 +421,6 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
                 final AWSKinesisVideoSignalingClient awsKinesisVideoSignalingClient = mFragment.get().getAwsKinesisVideoSignalingClient(region, dataEndpoint);
                 GetIceServerConfigResult getIceServerConfigResult = awsKinesisVideoSignalingClient.getIceServerConfig(
                         new GetIceServerConfigRequest().withChannelARN(mFragment.get().mChannelArn).withClientId(role.name()));
-                System.err.println("OOOOOO " + getIceServerConfigResult.getIceServerList());
                 mFragment.get().mIceServerList.addAll(getIceServerConfigResult.getIceServerList());
             } catch (Exception e) {
                 return "Get Ice Server Config failed with Exception " + e.getLocalizedMessage();

--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -1,6 +1,7 @@
 package com.amazonaws.kinesisvideo.demoapp.fragment;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
@@ -10,6 +11,7 @@ import android.util.SparseBooleanArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -53,6 +55,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class StreamWebRtcConfigurationFragment extends Fragment {
     private static final String TAG = StreamWebRtcConfigurationFragment.class.getSimpleName();
@@ -193,16 +196,18 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
 
     private void startMasterActivity() {
 
-        // Check that the "Send Audio" and "Send Video" boxes are enabled.
-        final SparseBooleanArray checked = mOptions.getCheckedItemPositions();
-        for (int i = 0; i < mOptions.getCount(); i++) {
-            if (!checked.get(i)) {
-                new AlertDialog.Builder(getActivity())
-                        .setPositiveButton("OK", null)
-                        .setMessage("Audio and video must be sent to ingest media!")
-                        .create()
-                        .show();
-                return;
+        if (mIngestMedia.isChecked()) {
+            // Check that the "Send Audio" and "Send Video" boxes are enabled.
+            final SparseBooleanArray checked = mOptions.getCheckedItemPositions();
+            for (int i = 0; i < mOptions.getCount(); i++) {
+                if (!checked.get(i)) {
+                    new AlertDialog.Builder(getActivity())
+                            .setPositiveButton("OK", null)
+                            .setMessage("Audio and video must be sent to ingest media!")
+                            .create()
+                            .show();
+                    return;
+                }
             }
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/SignalingListener.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/SignalingListener.java
@@ -3,8 +3,10 @@ package com.amazonaws.kinesisvideo.signaling;
 
 import android.util.Base64;
 import android.util.Log;
+
 import com.amazonaws.kinesisvideo.signaling.model.Event;
 import com.google.gson.Gson;
+
 import javax.websocket.MessageHandler;
 
 public abstract class SignalingListener implements Signaling {
@@ -16,47 +18,44 @@ public abstract class SignalingListener implements Signaling {
     private final MessageHandler messageHandler = new MessageHandler.Whole<String>() {
 
         @Override
-        public void onMessage(String message) {
-
-            Log.d(TAG, "Received message" + message);
-
-            if (!message.isEmpty() && message.contains("messagePayload")) {
-
-                Event evt = gson.fromJson(message, Event.class);
-
-                if(evt != null && evt.getMessageType() != null && !evt.getMessagePayload().isEmpty()){
-
-                    if (evt.getMessageType().equalsIgnoreCase("SDP_OFFER")) {
-
-                        Log.d(TAG, "Offer received: SenderClientId="  + evt.getSenderClientId());
-
-                        byte[] decode = Base64.decode(evt.getMessagePayload(), 0);
-
-                        Log.d(TAG, new String(decode));
-
-                        onSdpOffer(evt);
-                    }
-
-                    if (evt.getMessageType().equalsIgnoreCase("SDP_ANSWER")) {
-
-                        Log.d(TAG, "Answer received: SenderClientId="  + evt.getSenderClientId());
-
-                        onSdpAnswer(evt);
-                    }
-
-                    if (evt.getMessageType().equalsIgnoreCase("ICE_CANDIDATE")) {
-
-                        Log.d(TAG, "Ice Candidate received: SenderClientId="  + evt.getSenderClientId());
-
-                        byte[] decode = Base64.decode(evt.getMessagePayload(), 0);
-
-                        Log.d(TAG, new String(decode));
-
-                        onIceCandidate(evt);
-                    }
-                }
+        public void onMessage(final String message) {
+            if (message.isEmpty()) {
+                return;
             }
 
+            Log.d(TAG, "Received message: " + message);
+
+            if (!message.contains("messagePayload")) {
+                return;
+            }
+
+            final Event evt = gson.fromJson(message, Event.class);
+
+            if (evt == null || evt.getMessageType() == null || evt.getMessagePayload().isEmpty()) {
+                return;
+            }
+
+            switch (evt.getMessageType().toUpperCase()) {
+                case "SDP_OFFER":
+                    Log.d(TAG, "Offer received: SenderClientId=" + evt.getSenderClientId());
+                    Log.d(TAG, new String(Base64.decode(evt.getMessagePayload(), 0)));
+
+                    onSdpOffer(evt);
+                    break;
+                case "SDP_ANSWER":
+                    Log.d(TAG, "Answer received: SenderClientId=" + evt.getSenderClientId());
+
+                    onSdpAnswer(evt);
+                    break;
+                case "ICE_CANDIDATE":
+                    Log.d(TAG, "Ice Candidate received: SenderClientId=" + evt.getSenderClientId());
+                    Log.d(TAG, new String(Base64.decode(evt.getMessagePayload(), 0)));
+
+                    onIceCandidate(evt);
+                    break;
+                default:
+                    break;
+            }
         }
     };
 

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
@@ -143,4 +143,14 @@ public class Event {
                 .orElse("");
     }
 
+    @Override
+    public String toString() {
+        return "Event(" +
+                "senderClientId='" + senderClientId + '\'' +
+                ", messageType='" + messageType + '\'' +
+                ", messagePayload='" + messagePayload + '\'' +
+                ", statusCode='" + statusCode + '\'' +
+                ", body='" + body + '\'' +
+                ')';
+    }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
@@ -2,19 +2,30 @@ package com.amazonaws.kinesisvideo.signaling.model;
 
 import android.util.Base64;
 import android.util.Log;
+
+import com.google.common.base.Charsets;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+
 import org.webrtc.IceCandidate;
 
+import java.util.Optional;
+
+/**
+ * A class representing the Event object.
+ *
+ * @see <a href="https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-7.html">Event</a>
+ */
 public class Event {
 
     private static final String TAG = "Event";
 
-    private String senderClientId;
+    private final String senderClientId;
 
-    private String messageType;
+    private final String messageType;
 
-    private String messagePayload;
+    private final String messagePayload;
 
     private String statusCode;
 
@@ -48,62 +59,87 @@ public class Event {
         return messagePayload;
     }
 
-    public Event() {}
 
-    public Event(String senderClientId, String messageType, String messagePayload) {
+    public Event(final String senderClientId, final String messageType, final String messagePayload) {
         this.senderClientId = senderClientId;
         this.messageType = messageType;
         this.messagePayload = messagePayload;
     }
 
-    public static IceCandidate parseIceCandidate(Event event) {
-
-        byte[] decode = Base64.decode(event.getMessagePayload(), Base64.DEFAULT);
-        String candidateString = new String(decode);
-
-        JsonObject jsonObject = JsonParser.parseString(candidateString).getAsJsonObject();
-
-        String sdpMid = jsonObject.get("sdpMid").toString();
-        if (sdpMid.length() > 2) {
-            sdpMid = sdpMid.substring(1, sdpMid.length() - 1);
-        }
-
-        int sdpMLineIndex = 0;
-        try {
-            sdpMLineIndex = Integer.parseInt(jsonObject.get("sdpMLineIndex").toString());
-        } catch (NumberFormatException e) {
-            Log.e(TAG,  "Invalid sdpMLineIndex");
+    /**
+     * Attempts to convert an {@code ICE_CANDIDATE} {@link Event} into an {@link IceCandidate}.
+     *
+     * @param event the ICE_CANDIDATE event to convert.
+     * @return an {@link IceCandidate} from the {@link Event}. {@code null} if the IceCandidate wasn't
+     * able to be constructed.
+     */
+    public static IceCandidate parseIceCandidate(final Event event) {
+        if (event == null || !"ICE_CANDIDATE".equalsIgnoreCase(event.getMessageType())) {
+            Log.e(TAG, event + " is not an ICE_CANDIDATE type!");
             return null;
         }
 
-        String candidate = jsonObject.get("candidate").toString();
-        if (candidate.length() > 2) {
-            candidate = candidate.substring(1, candidate.length() - 1);
+        final byte[] decode = Base64.decode(event.getMessagePayload(), Base64.DEFAULT);
+        final String candidateString = new String(decode, Charsets.UTF_8);
+
+        if (candidateString.equals("null")) {
+            Log.w(TAG, "Received null IceCandidate!");
+            return null;
         }
 
-        return new IceCandidate(sdpMid, sdpMLineIndex, candidate);
+        final JsonObject jsonObject = JsonParser.parseString(candidateString).getAsJsonObject();
+
+        final String sdpMid = Optional.ofNullable(jsonObject.get("sdpMid"))
+                .map(Object::toString)
+                // Remove quotes
+                .map(sdpMidStr -> sdpMidStr.length() > 2 ? sdpMidStr.substring(1, sdpMidStr.length() - 1) : sdpMidStr)
+                .orElse("");
+
+        int sdpMLineIndex = -1;
+        try {
+            sdpMLineIndex = Integer.parseInt(jsonObject.get("sdpMLineIndex").toString());
+        } catch (final NumberFormatException e) {
+            Log.e(TAG, "Invalid sdpMLineIndex");
+        }
+
+        // Ice Candidate needs one of these two to be present
+        if (sdpMid.isEmpty() && sdpMLineIndex == -1) {
+            return null;
+        }
+
+        final String candidate = Optional.ofNullable(jsonObject.get("candidate"))
+                .map(Object::toString)
+                // Remove quotes
+                .map(candidateStr -> candidateStr.length() > 2 ? candidateStr.substring(1, candidateStr.length() - 1) : candidateStr)
+                .orElse("");
+
+        return new IceCandidate(sdpMid, sdpMLineIndex == -1 ? 0 : sdpMLineIndex, candidate);
     }
 
-    public static String parseSdpEvent(Event answerEvent) {
+    public static String parseSdpEvent(final Event answerEvent) {
 
-        String message = new String(Base64.decode(answerEvent.getMessagePayload().getBytes(), Base64.DEFAULT));
-        JsonObject jsonObject = JsonParser.parseString(message).getAsJsonObject();
-        String type = jsonObject.get("type").toString();
+        final String message = new String(Base64.decode(answerEvent.getMessagePayload().getBytes(), Base64.DEFAULT));
+        final JsonObject jsonObject = JsonParser.parseString(message).getAsJsonObject();
+        final String type = jsonObject.get("type").toString();
 
         if (!type.equalsIgnoreCase("\"answer\"")) {
             Log.e(TAG, "Error in answer message");
         }
 
-        String sdp = jsonObject.get("sdp").getAsString();
-        Log.d(TAG, "SDP answer received from master:" + sdp);
+        final String sdp = jsonObject.get("sdp").getAsString();
+        Log.d(TAG, "SDP answer received from master: " + sdp);
         return sdp;
     }
 
     public static String parseOfferEvent(Event offerEvent) {
-        String s = new String(Base64.decode(offerEvent.getMessagePayload(), Base64.DEFAULT));
+        final String s = new String(Base64.decode(offerEvent.getMessagePayload(), Base64.DEFAULT));
 
-        JsonObject jsonObject = JsonParser.parseString(s).getAsJsonObject();
-        return jsonObject.get("sdp").getAsString();
+        return Optional.of(JsonParser.parseString(s))
+                .filter(JsonElement::isJsonObject)
+                .map(JsonElement::getAsJsonObject)
+                .map(jsonObject -> jsonObject.get("sdp"))
+                .map(JsonElement::getAsString)
+                .orElse("");
     }
 
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Event.java
@@ -13,7 +13,8 @@ import org.webrtc.IceCandidate;
 import java.util.Optional;
 
 /**
- * A class representing the Event object.
+ * A class representing the Event object. All response messages are asynchronously delivered
+ * to the recipient as events (for example, an SDP offer or SDP answer delivery).
  *
  * @see <a href="https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-7.html">Event</a>
  */

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Message.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Message.java
@@ -70,7 +70,7 @@ public class Message {
 
         final String answerPayload = "{\"type\":\"answer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
 
-        final String encodedString = new String(Base64.encode(answerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
+        final String encodedString = new String(Base64.encode(answerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_WRAP));
 
         // SenderClientId should always be "" for master creating answer case
         return new Message("SDP_ANSWER", recipientClientId, "", encodedString);
@@ -78,7 +78,7 @@ public class Message {
 
 
     /**
-     * @param sessionDescription SDP description to be converted  as Offer Message & sent to signaling service
+     * @param sessionDescription SDP description to be converted as Offer Message & sent to signaling service
      * @param clientId           Client Id to mark this viewer in signaling service
      * @return SDP Offer message to be sent to signaling service
      */
@@ -88,7 +88,7 @@ public class Message {
 
         final String offerPayload = "{\"type\":\"offer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
 
-        final String encodedString = new String(Base64.encode(offerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
+        final String encodedString = new String(Base64.encode(offerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_WRAP));
 
         return new Message("SDP_OFFER", "", clientId, encodedString);
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Message.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/model/Message.java
@@ -1,6 +1,7 @@
 package com.amazonaws.kinesisvideo.signaling.model;
 
 import android.util.Base64;
+
 import org.webrtc.SessionDescription;
 
 public class Message {
@@ -14,22 +15,21 @@ public class Message {
     private String messagePayload;
 
 
-    public Message() {}
+    public Message() {
+    }
 
-    public Message(String action, String recipientClientId, String senderClientId, String messagePayload) {
-
+    public Message(final String action, final String recipientClientId, final String senderClientId, final String messagePayload) {
         this.action = action;
         this.recipientClientId = recipientClientId;
         this.senderClientId = senderClientId;
         this.messagePayload = messagePayload;
-
     }
 
     public String getAction() {
         return action;
     }
 
-    public void setAction(String action) {
+    public void setAction(final String action) {
         this.action = action;
     }
 
@@ -37,7 +37,7 @@ public class Message {
         return recipientClientId;
     }
 
-    public void setRecipientClientId(String recipientClientId) {
+    public void setRecipientClientId(final String recipientClientId) {
         this.recipientClientId = recipientClientId;
     }
 
@@ -45,7 +45,7 @@ public class Message {
         return senderClientId;
     }
 
-    public void setSenderClientId(String senderClientId) {
+    public void setSenderClientId(final String senderClientId) {
         this.senderClientId = senderClientId;
     }
 
@@ -53,24 +53,24 @@ public class Message {
         return messagePayload;
     }
 
-    public void setMessagePayload(String messagePayload) {
+    public void setMessagePayload(final String messagePayload) {
         this.messagePayload = messagePayload;
     }
 
 
     /**
      * @param sessionDescription SDP description to be converted & sent to signaling service
-     * @param master true if local is set to be the master
-     * @param recipientClientId - has to be set to null if this is set as viewer
+     * @param master             true if local is set to be the master
+     * @param recipientClientId  - has to be set to null if this is set as viewer
      * @return SDP Answer message to be sent to signaling service
      */
-    public static  Message createAnswerMessage(SessionDescription sessionDescription, boolean master, String recipientClientId) {
+    public static Message createAnswerMessage(final SessionDescription sessionDescription, final boolean master, final String recipientClientId) {
 
-        String description = sessionDescription.description;
+        final String description = sessionDescription.description;
 
-        String answerPayload = "{\"type\":\"answer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
+        final String answerPayload = "{\"type\":\"answer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
 
-        String encodedString = new String(Base64.encode(answerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
+        final String encodedString = new String(Base64.encode(answerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
 
         // SenderClientId should always be "" for master creating answer case
         return new Message("SDP_ANSWER", recipientClientId, "", encodedString);
@@ -79,16 +79,16 @@ public class Message {
 
     /**
      * @param sessionDescription SDP description to be converted  as Offer Message & sent to signaling service
-     * @param clientId Client Id to mark this viewer in signaling service
+     * @param clientId           Client Id to mark this viewer in signaling service
      * @return SDP Offer message to be sent to signaling service
      */
-    public static Message createOfferMessage(SessionDescription sessionDescription, String clientId) {
+    public static Message createOfferMessage(final SessionDescription sessionDescription, final String clientId) {
 
-        String description = sessionDescription.description;
+        final String description = sessionDescription.description;
 
-        String offerPayload = "{\"type\":\"offer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
+        final String offerPayload = "{\"type\":\"offer\",\"sdp\":\"" + description.replace("\r\n", "\\r\\n") + "\"}";
 
-        String encodedString = new String(Base64.encode(offerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
+        final String encodedString = new String(Base64.encode(offerPayload.getBytes(), Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP));
 
         return new Message("SDP_OFFER", "", clientId, encodedString);
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/SignalingServiceWebSocketClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/SignalingServiceWebSocketClient.java
@@ -2,10 +2,11 @@ package com.amazonaws.kinesisvideo.signaling.tyrus;
 
 import android.util.Base64;
 import android.util.Log;
-import com.amazonaws.kinesisvideo.signaling.SignalingListener;
 
+import com.amazonaws.kinesisvideo.signaling.SignalingListener;
 import com.amazonaws.kinesisvideo.signaling.model.Message;
 import com.google.gson.Gson;
+
 import org.glassfish.tyrus.client.ClientManager;
 
 import java.util.concurrent.ExecutorService;
@@ -66,16 +67,12 @@ public class SignalingServiceWebSocketClient {
     }
 
     public void sendIceCandidate(final Message candidate) {
-        executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                if (candidate.getAction().equalsIgnoreCase("ICE_CANDIDATE")) {
-
-                    send(candidate);
-                }
-
-                Log.d(TAG, "Sent Ice candidate message");
+        executorService.submit(() -> {
+            if (candidate.getAction().equalsIgnoreCase("ICE_CANDIDATE")) {
+                send(candidate);
             }
+
+            Log.d(TAG, "Sent Ice candidate message");
         });
     }
 
@@ -87,14 +84,17 @@ public class SignalingServiceWebSocketClient {
             }
         });
         try {
-            executorService.awaitTermination(1, TimeUnit.SECONDS);
+            executorService.shutdown();
+            if (!executorService.awaitTermination(1, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
         } catch (InterruptedException e) {
             Log.e(TAG, "Error in disconnect");
         }
     }
 
     private void send(final Message message) {
-        String jsonMessage = gson.toJson(message);
+        final String jsonMessage = gson.toJson(message);
         Log.d(TAG, "Sending JSON Message= " + jsonMessage);
         websocketClient.send(jsonMessage);
         Log.d(TAG, "Sent JSON Message= " + jsonMessage);

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/SignalingServiceWebSocketClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/SignalingServiceWebSocketClient.java
@@ -58,7 +58,7 @@ public class SignalingServiceWebSocketClient {
                 if (answer.getAction().equalsIgnoreCase("SDP_ANSWER")) {
 
                     Log.d(TAG, "Answer sent " + new String(Base64.decode(answer.getMessagePayload().getBytes(),
-                            Base64.NO_WRAP | Base64.NO_PADDING | Base64.URL_SAFE)));
+                            Base64.NO_WRAP | Base64.URL_SAFE)));
 
                     send(answer);
                 }

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/WebSocketClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/WebSocketClient.java
@@ -4,8 +4,9 @@ import static org.awaitility.Awaitility.await;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.amazonaws.kinesisvideo.signaling.SignalingListener;
-import com.amazonaws.kinesisvideo.utils.Constants;
 
 import org.glassfish.tyrus.client.ClientManager;
 import org.glassfish.tyrus.client.ClientProperties;
@@ -13,9 +14,6 @@ import org.glassfish.tyrus.client.ClientProperties;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -24,7 +22,6 @@ import javax.websocket.CloseReason;
 import javax.websocket.DeploymentException;
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
-import javax.websocket.HandshakeResponse;
 import javax.websocket.Session;
 
 /**
@@ -43,25 +40,9 @@ class WebSocketClient {
                     final ExecutorService executorService) {
 
         this.executorService = executorService;
-        final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
-                .configurator(new ClientEndpointConfig.Configurator() {
+        final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
 
-                    // Add headers to the WebSocket messages
-                    @Override
-                    public void beforeRequest(final Map<String, List<String>> headers) {
-                        super.beforeRequest(headers);
-                        final String userAgent = Constants.APP_NAME + "/" + Constants.VERSION + " " +
-                                (System.getProperty("http.agent") == null ? "" : System.getProperty("http.agent"));
-                        headers.put("userAgent", Collections.singletonList(userAgent.trim()));
-                    }
-
-                    @Override
-                    public void afterResponse(final HandshakeResponse hr) {
-                        final Map<String, List<String>> headers = hr.getHeaders();
-                        Log.i(TAG, "headers -> " + headers);
-                    }
-                })
-                .build();
+        cec.getUserProperties().put("userAgent", "my-verycool-test-user-agent");
 
         clientManager.getProperties().put(ClientProperties.LOG_HTTP_UPGRADE, true);
 
@@ -109,7 +90,7 @@ class WebSocketClient {
         return session.isOpen();
     }
 
-    void send(final String message) {
+    void send(@NonNull final String message) {
         if (!this.isOpen()) {
             Log.e(TAG, "Connection isn't open!");
             return;
@@ -130,6 +111,7 @@ class WebSocketClient {
 
         if (!session.isOpen()) {
             Log.w(TAG, "Connection already closed for " + session.getRequestURI());
+            return;
         }
 
         try {

--- a/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/WebSocketClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/signaling/tyrus/WebSocketClient.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.amazonaws.kinesisvideo.signaling.SignalingListener;
+import com.amazonaws.kinesisvideo.utils.Constants;
 
 import org.glassfish.tyrus.client.ClientManager;
 import org.glassfish.tyrus.client.ClientProperties;
@@ -42,7 +43,11 @@ class WebSocketClient {
         this.executorService = executorService;
         final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
 
-        cec.getUserProperties().put("userAgent", "my-verycool-test-user-agent");
+        System.getProperties().forEach((k, v) -> System.err.println(k + ": " + v));
+
+        final String userAgent = Constants.APP_NAME + "/" + Constants.VERSION + System.getProperty("http.user");
+
+        cec.getUserProperties().put("userAgent", "my-cool-agent");
 
         clientManager.getProperties().put(ClientProperties.LOG_HTTP_UPGRADE, true);
 

--- a/src/main/java/com/amazonaws/kinesisvideo/utils/AwsV4Signer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/utils/AwsV4Signer.java
@@ -58,7 +58,6 @@ public class AwsV4Signer {
                            final String sessionToken, final URI wssUri, final String region) {
 
         final long dateMilli = new Date().getTime();
-        System.err.println(dateMilli);
         final String amzDate = getTimeStamp(dateMilli);
         final String datestamp = getDateStamp(dateMilli);
 

--- a/src/main/java/com/amazonaws/kinesisvideo/utils/AwsV4Signer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/utils/AwsV4Signer.java
@@ -1,5 +1,11 @@
 package com.amazonaws.kinesisvideo.utils;
 
+import static com.google.common.hash.Hashing.sha256;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.amazonaws.util.BinaryUtils;
 import com.amazonaws.util.DateUtils;
 import com.google.common.collect.ImmutableMap;
@@ -23,12 +29,6 @@ import java.util.StringJoiner;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
-import static com.google.common.hash.Hashing.sha256;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @SuppressWarnings({"SpellCheckingInspection", "SameParameterValue"})
 public class AwsV4Signer {
@@ -58,6 +58,7 @@ public class AwsV4Signer {
                            final String sessionToken, final URI wssUri, final String region) {
 
         final long dateMilli = new Date().getTime();
+        System.err.println(dateMilli);
         final String amzDate = getTimeStamp(dateMilli);
         final String datestamp = getDateStamp(dateMilli);
 
@@ -123,7 +124,7 @@ public class AwsV4Signer {
                 .add(payloadHash)
                 .toString();
 
-       return canonicalRequest;
+        return canonicalRequest;
     }
 
     private static String getCanonicalUri(URI uri) {

--- a/src/main/java/com/amazonaws/kinesisvideo/utils/Constants.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/utils/Constants.java
@@ -9,4 +9,14 @@ public class Constants {
      * SDK version identifier
      */
     public static final String VERSION = "1.0.0";
+
+    /**
+     * Query parameter for Channel ARN. Used for calling Kinesis Video Websocket APIs.
+     */
+    public static final String CHANNEL_ARN_QUERY_PARAM = "X-Amz-ChannelARN";
+
+    /**
+     * Query parameter for Client Id. Only used for viewers. Used for calling Kinesis Video Websocket APIs.
+     */
+    public static final String CLIENT_ID_QUERY_PARAM = "X-Amz-ClientId";
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/utils/Constants.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/utils/Constants.java
@@ -1,0 +1,12 @@
+package com.amazonaws.kinesisvideo.utils;
+
+public class Constants {
+    /**
+     * SDK identifier
+     */
+    public static final String APP_NAME = "aws-kvs-webrtc-android-client";
+    /**
+     * SDK version identifier
+     */
+    public static final String VERSION = "1.0.0";
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/webrtc/KinesisVideoPeerConnection.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/webrtc/KinesisVideoPeerConnection.java
@@ -1,12 +1,17 @@
 package com.amazonaws.kinesisvideo.webrtc;
 
 import android.util.Log;
+
+import org.webrtc.CandidatePairChangeEvent;
 import org.webrtc.DataChannel;
 import org.webrtc.IceCandidate;
 import org.webrtc.MediaStream;
 import org.webrtc.PeerConnection;
 import org.webrtc.RtpReceiver;
 
+/**
+ * Listener for Peer connection events. Prints event info to the logs at debug level.
+ */
 public class KinesisVideoPeerConnection implements PeerConnection.Observer {
 
     private final static String TAG = "KVSPeerConnection";
@@ -15,69 +20,116 @@ public class KinesisVideoPeerConnection implements PeerConnection.Observer {
 
     }
 
+    /**
+     * Triggered when the SignalingState changes.
+     */
     @Override
-    public void onSignalingChange(PeerConnection.SignalingState signalingState) {
+    public void onSignalingChange(final PeerConnection.SignalingState signalingState) {
 
         Log.d(TAG, "onSignalingChange(): signalingState = [" + signalingState + "]");
 
     }
 
+    /**
+     * Triggered when the IceConnectionState changes.
+     */
     @Override
-    public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
+    public void onIceConnectionChange(final PeerConnection.IceConnectionState iceConnectionState) {
 
         Log.d(TAG, "onIceConnectionChange(): iceConnectionState = [" + iceConnectionState + "]");
 
     }
 
+    /**
+     * Triggered when the ICE connection receiving status changes.
+     */
     @Override
-    public void onIceConnectionReceivingChange(boolean connectionChange) {
+    public void onIceConnectionReceivingChange(final boolean connectionChange) {
 
         Log.d(TAG, "onIceConnectionReceivingChange(): connectionChange = [" + connectionChange + "]");
 
     }
 
+    /**
+     * Triggered when the IceGatheringState changes.
+     */
     @Override
-    public void onIceGatheringChange(PeerConnection.IceGatheringState iceGatheringState) {
+    public void onIceGatheringChange(final PeerConnection.IceGatheringState iceGatheringState) {
 
         Log.d(TAG, "onIceGatheringChange(): iceGatheringState = [" + iceGatheringState + "]");
 
     }
 
+    /**
+     * Triggered when a new ICE candidate has been found.
+     */
     @Override
-    public void onIceCandidate(IceCandidate iceCandidate) {
+    public void onIceCandidate(final IceCandidate iceCandidate) {
 
         Log.d(TAG, "onIceCandidate(): iceCandidate = [" + iceCandidate + "]");
 
     }
 
+    /**
+     * Triggered when some ICE candidates have been removed.
+     */
     @Override
-    public void onIceCandidatesRemoved(IceCandidate[] iceCandidates) {
+    public void onIceCandidatesRemoved(final IceCandidate[] iceCandidates) {
 
         Log.d(TAG, "onIceCandidatesRemoved(): iceCandidates Length = [" + iceCandidates.length + "]");
 
     }
 
+    /**
+     * Triggered when the ICE candidate pair is changed.
+     */
     @Override
-    public void onAddStream(MediaStream mediaStream) {
+    public void onSelectedCandidatePairChanged(final CandidatePairChangeEvent event) {
+
+        final String eventString = "{" +
+                String.join(", ",
+                        "reason: " + event.reason,
+                        "remote: " + event.remote,
+                        "local: " + event.local,
+                        "lastReceivedMs: " + event.lastDataReceivedMs) +
+                "}";
+        Log.d(TAG, "onSelectedCandidatePairChanged(): event = " + eventString);
+
+    }
+
+    /**
+     * Triggered when media is received on a new stream from remote peer.
+     */
+    @Override
+    public void onAddStream(final MediaStream mediaStream) {
 
         Log.d(TAG, "onAddStream(): mediaStream = [" + mediaStream + "]");
 
     }
 
+    /**
+     * Triggered when a remote peer close a stream.
+     */
     @Override
-    public void onRemoveStream(MediaStream mediaStream) {
+    public void onRemoveStream(final MediaStream mediaStream) {
 
         Log.d(TAG, "onRemoveStream(): mediaStream = [" + mediaStream + "]");
 
     }
 
+    /**
+     * Triggered when a remote peer opens a DataChannel.
+     */
     @Override
-    public void onDataChannel(DataChannel dataChannel) {
+    public void onDataChannel(final DataChannel dataChannel) {
 
         Log.d(TAG, "onDataChannel(): dataChannel = [" + dataChannel + "]");
 
     }
 
+    /**
+     * Triggered when renegotiation is necessary.
+     */
     @Override
     public void onRenegotiationNeeded() {
 
@@ -85,8 +137,11 @@ public class KinesisVideoPeerConnection implements PeerConnection.Observer {
 
     }
 
+    /**
+     * Triggered when a new track is signaled by the remote peer, as a result of setRemoteDescription.
+     */
     @Override
-    public void onAddTrack(RtpReceiver rtpReceiver, MediaStream[] mediaStreams) {
+    public void onAddTrack(final RtpReceiver rtpReceiver, final MediaStream[] mediaStreams) {
 
         Log.d(TAG, "onAddTrack(): rtpReceiver = [" + rtpReceiver + "], " +
                 "mediaStreams Length = [" + mediaStreams.length + "]");

--- a/src/main/java/com/amazonaws/kinesisvideo/webrtc/KinesisVideoSdpObserver.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/webrtc/KinesisVideoSdpObserver.java
@@ -1,6 +1,7 @@
 package com.amazonaws.kinesisvideo.webrtc;
 
 import android.util.Log;
+
 import org.webrtc.SdpObserver;
 import org.webrtc.SessionDescription;
 
@@ -9,7 +10,7 @@ public class KinesisVideoSdpObserver implements SdpObserver {
     protected static final String TAG = KinesisVideoSdpObserver.class.getSimpleName();
 
     @Override
-    public void onCreateSuccess(SessionDescription sessionDescription) {
+    public void onCreateSuccess(final SessionDescription sessionDescription) {
 
         Log.d(TAG, "onCreateSuccess(): SDP=" + sessionDescription.description);
     }

--- a/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -95,6 +95,8 @@
             android:text="Ingest media (master only)"
             android:layoutDirection="rtl"
             android:id="@+id/ingest_media"
+            android:layout_margin="16dp"
+            android:textSize="16sp"
             tools:ignore="HardcodedText" />
 
         <ListView
@@ -106,30 +108,34 @@
             android:layout_width="match_parent"
             android:layout_height="20dp" />
 
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/start_master"
-            android:text="Start Master"
-            android:padding="10dp"
-            android:background="@drawable/button_selector"
-            android:layout_gravity="center"
-            android:layout_margin="10dp"
-            tools:ignore="HardcodedText" />
-
-        <Space
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="20dp" />
-
-        <Button
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/start_viewer"
-            android:text="Start Viewer"
-            android:layout_gravity="center"
-            android:padding="10dp"
-            android:background="@drawable/button_selector"
-            android:layout_margin="10dp"
-            tools:ignore="HardcodedText" />
+            android:orientation="horizontal"
+            android:gravity="center">
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/start_master"
+                android:text="Start Master"
+                android:padding="10dp"
+                android:background="@drawable/button_selector"
+                android:layout_gravity="center"
+                android:layout_margin="10dp"
+                tools:ignore="HardcodedText" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/start_viewer"
+                android:text="Start Viewer"
+                android:layout_gravity="center"
+                android:padding="10dp"
+                android:background="@drawable/button_selector"
+                android:layout_margin="10dp"
+                tools:ignore="HardcodedText" />
+
+        </LinearLayout>
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -3,120 +3,133 @@
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
     <LinearLayout
         android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="20dp"
-                    android:orientation="vertical">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Channel Name"
-                tools:ignore="HardcodedText" />
-            <EditText
-                android:id="@+id/channel_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text="demo-channel"
-                android:maxLength="256"
-                android:hint="Channel name with letter, number and ._-"
-                tools:ignore="Autofill,HardcodedText"
-                android:inputType="text" />
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:orientation="vertical">
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Channel Name"
+            tools:ignore="HardcodedText" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Client Id"
-                tools:ignore="HardcodedText" />
+        <EditText
+            android:id="@+id/channel_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="demo-channel"
+            android:maxLength="256"
+            android:hint="Channel name with letter, number and ._-"
+            tools:ignore="Autofill,HardcodedText"
+            android:inputType="text" />
 
-            <EditText
-                android:id="@+id/client_id"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text=""
-                android:hint="Client Id (optional)"
-                android:inputType="text"
-                tools:ignore="Autofill,HardcodedText" />
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Client Id"
+            tools:ignore="HardcodedText" />
+
+        <EditText
+            android:id="@+id/client_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text=""
+            android:hint="Client Id (optional)"
+            android:inputType="text"
+            tools:ignore="Autofill,HardcodedText" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
 
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Region"
-                tools:ignore="HardcodedText" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Region"
+            tools:ignore="HardcodedText" />
 
-            <EditText
-                android:id="@+id/region"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text="us-west-2"
-                android:hint="Region in all lower case."
-                tools:ignore="Autofill,HardcodedText"
-                android:inputType="text" />
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <EditText
+            android:id="@+id/region"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="us-west-2"
+            android:hint="Region in all lower case."
+            tools:ignore="Autofill,HardcodedText"
+            android:inputType="text" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Camera"
-                tools:ignore="HardcodedText" />
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
 
-            <Spinner
-                android:layout_width="match_parent"
-                android:layout_height="20dp"
-                android:id="@+id/camera_spinner" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Camera"
+            tools:ignore="HardcodedText" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <Spinner
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:id="@+id/camera_spinner" />
 
-            <ListView
-                android:layout_width="match_parent"
-                android:layout_height="100dp"
-                android:id="@+id/webrtc_options" />
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <CheckBox
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Ingest media (master only)"
+            android:layoutDirection="rtl"
+            android:id="@+id/ingest_media"
+            tools:ignore="HardcodedText" />
 
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/start_master"
-                android:text="Start Master"
-                android:padding="10dp"
-                android:background="@drawable/button_selector"
-                android:layout_gravity="center"
-                android:layout_margin="10dp"
-                tools:ignore="HardcodedText" />
+        <ListView
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:id="@+id/webrtc_options" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
 
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/start_viewer"
-                android:text="Start Viewer"
-                android:layout_gravity="center"
-                android:padding="10dp"
-                android:background="@drawable/button_selector"
-                android:layout_margin="10dp"
-                tools:ignore="HardcodedText" />
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/start_master"
+            android:text="Start Master"
+            android:padding="10dp"
+            android:background="@drawable/button_selector"
+            android:layout_gravity="center"
+            android:layout_margin="10dp"
+            tools:ignore="HardcodedText" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/start_viewer"
+            android:text="Start Viewer"
+            android:layout_gravity="center"
+            android:padding="10dp"
+            android:background="@drawable/button_selector"
+            android:layout_margin="10dp"
+            tools:ignore="HardcodedText" />
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/src/test/java/com/amazonaws/kinesisvideo/demoapp/ExampleUnitTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/demoapp/ExampleUnitTest.java
@@ -8,6 +8,7 @@ class ExampleUnitTest {
             final ByteBuffer a,
             final ByteBuffer b) {
 
+
         if (a.limit() != b.limit()) {
             return false;
         }

--- a/src/test/java/com/amazonaws/kinesisvideo/utils/AwsV4SignerTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/utils/AwsV4SignerTest.java
@@ -1,5 +1,8 @@
 package com.amazonaws.kinesisvideo.utils;
 
+import static com.amazonaws.kinesisvideo.utils.AwsV4Signer.*;
+import static org.junit.Assert.assertEquals;
+
 import com.amazonaws.util.BinaryUtils;
 
 import org.junit.Test;
@@ -8,9 +11,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.amazonaws.kinesisvideo.utils.AwsV4Signer.*;
-import static org.junit.Assert.*;
-
 public class AwsV4SignerTest {
 
 // https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html#signature-v4-test-suite-example
@@ -18,7 +18,7 @@ public class AwsV4SignerTest {
     @Test
     public void getCanonicalRequestTest() {
 
-        String canonicalResultExpected=
+        String canonicalResultExpected =
                 "GET\n" +
                         "/\n" +
                         "Param1=value1&Param2=value2\n" +
@@ -29,15 +29,14 @@ public class AwsV4SignerTest {
 
         URI uri = URI.create("http://example.amazonaws.com");
 
-        Map<String, String> paramsMap =  new HashMap<String,String>() {{
-            put ("Param1", "value1");
+        Map<String, String> paramsMap = new HashMap<String, String>() {{
+            put("Param1", "value1");
             put("Param2", "value2");
         }};
 
         String canonicalQuerystring = getCanonicalRequest(uri, getCanonicalizedQueryString(paramsMap));
 
-        assertEquals(canonicalResultExpected,canonicalQuerystring);
-
+        assertEquals(canonicalResultExpected, canonicalQuerystring);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
* Add the WebRTC storage feature to the sample app. For more information about WebRTC Ingestion, see [the documentation](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html).
* Add a new checkbox, allowing the feature to be enabled. Also adjust the Start Master and Start Viewer side-by-side to take up less room. 

| Before  | After |
| ------------- | ------------- |
| <img width="281" alt="image (9)" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/9aed1ac6-4209-458d-bf0b-44cf0bf2fa4e"> | <img width="272" alt="image (10)" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/76e93e6e-61f8-456e-ae37-becac0d71f53"> |
* Add error dialog boxes in case certain WebRTC Storage requirements aren't yet met:

| Screenshot  | Note |
| ------------- | ------------- |
| <img width="361" alt="image (12)" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/223891b9-e693-409f-bb50-45c1dfdab3a9"> | If the Media Storage Configuration is not set to ENABLED. To enable it, use the [UpdateMediaStorageConfiguration API](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_UpdateMediaStorageConfiguration.html). |
| <img width="281" alt="image (11)" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/77e345ee-e274-4486-bc7e-ae4e4977eb49"> | If the Audio and Video checkboxes are not both checked. The WebRTC ingestion feature currently requires both audio and video tracks to be sent. |

* Add Toast messages for when peer connection succeeds or fails.

| Success  | Failure |
| ------------- | ------------- |
| <img width="281" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/41309cb1-d92e-4f97-9fc0-60916308f269"> | <img width="281" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/assets/14988194/918dcb3a-3446-44f5-8766-39e5a11301b5"> |

* Enable verbose logging for Google WebRTC's library (as specified [here](https://webrtc.github.io/webrtc-org/native-code/logging/)): `Logging.enableLogToDebugOutput(Logging.Severity.LS_INFO);`
  * Print out available encoders and decoders on the device to the logs.
* Bump the AWS SDK for Android dependencies to the latest. We need to do this in order to access the WebRTCStorage client.
* Add User Agent to the Websocket handshake. Note: The user agent is not sent with every websocket message, only during initialization of the Websocket connection.
* Add comments and Javadocs to various classes to hopefully make code more readable.
* Add toString to Event - that way we can see its contents instead of seeing `Event@123212`.
* Log the selected ice candidate pair - listen to the `onSelectedCandidatePairChanged` event.
* Fix code formatting.

> **Warning**
> The WebRTC ingestion feature requires that the device have H.264 support. Google's WebRTC will throw ERROR_CONTENT. Emulators might not support H.264, so it is recommend to try this feature using a real android device.

### Bug Fixes
* Fix an issue where receiving Ice candidates without both `sdpMid` and `sdpMLineIndex` would cause a failure.
* Fix an issue where receiving payload of null (e.g. `{"messagePayload":"bnVsbA==","messageType":"ICE_CANDIDATE"}`) would cause a failure.
* Fix an issue with encoding strings and missing padding, which would _sometimes_ cause the ice candidate connectivity checks to fail with the [`video producing device`](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_webrtc_JoinStorageSession.html). We add the padding by removing the NO_PADDING flag from the encoding settings: `new String(Base64.encode(payload.getBytes(), Base64.URL_SAFE | Base64.NO_WRAP)`.
* Fix an issue where if there was an exception in the AsyncTask in StreamWebRtcConfigurationFragment, we would still transition to the WebRtcActivity anyway.
* Avoid NullPointerException in various places. For example, when trying to read the Region from awsconfiguration.json, and also when parsing the message that does not contain the `sdp` property: `jsonObject.get("sdp").getAsString();`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
