### PR TITLE
Reorder accessKey and secretKey arguments

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -926,8 +926,8 @@ public class WebRtcActivity extends AppCompatActivity {
 
         return AwsV4Signer.sign(
                 URI.create(endpoint),
-                secretKey,
                 accessKey,
+                secretKey,
                 sessionToken,
                 URI.create(mWssEndpoint),
                 mRegion);


### PR DESCRIPTION
*Description of changes:*
Switch the accessKey and secretKey arguments passed to AWSV4Signer in the sample application.

*What was changed?*
Same as description

*Why was it changed?*
Accidentally put in the wrong order, causing a 403.
```
E/KVSWebRtcActivity: Signaling client returned exception: Handshake error.
E/KVSWebRtcActivity: Exception with websocket client: org.awaitility.core.ConditionTimeoutException: Condition with com.amazonaws.kinesisvideo.signaling.tyrus.- was not fulfilled within 10 seconds.
```

Testing:
Manually tested using my android device as master with the WebRTC ingestion feature, and also the JS sample.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
