### PR TITLE
Update tyrus version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.guava:guava:28.1-android'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.20') {
+    implementation('org.glassfish.tyrus.bundles:tyrus-standalone-client:1.21') {
         exclude module: 'javax.inject'
     }
 


### PR DESCRIPTION
## *Issue #, if available:*
n/a

## *Description of changes:*
* Tyrus is an open source Java API for WebSocket implementation. We use Tyrus' websocket client to connect to Kinesis Video Streams Signaling [as Master](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-2.html) or [Viewer](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-1.html).
* Bump `tyrus-standalone-client` from 1.20 to 1.21.
* https://mvnrepository.com/artifact/org.glassfish.tyrus.bundles/tyrus-standalone-client

## *Testing*
* Connect to [JS SDK](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js) as both master and viewer to confirm that the WebSocket connection is still established and no issues in connecting to KVS Signaling.
  * Also verify that the RTCPeerConnection still gets established.
  * Also verify that the sent and received media can be seen from both sides.

Note: This was tested in conjunction with libWebRTC `M114`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
