### PR TITLE
Fix Kotlin error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@
 plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.7.10' apply false
 }
 
 tasks.register('clean', Delete) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
/Users/niyatim/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio-jvm/3.6.0/5600569133b7bdefe1daf9ec7f4abeb6d13e1786/okio-jvm-3.6.0.jar!/META-INF/okio.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.
```
Tested by making sure that I don't see the same error when I follow these steps:

- `rm -rf ~/.gradle`
- `git clean -ffxd`
- Get the aar file if it was wiped out by the previous step
- Invalidate cache and restart Android Studio
- Sync gradle
- Make project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
