### PR TITLE
Add Cognito app client secret instructions comment

### DIFF
--- a/app/src/main/res/raw/awsconfiguration.json
+++ b/app/src/main/res/raw/awsconfiguration.json
@@ -13,7 +13,7 @@
   },
   "CognitoUserPool": {
     "Default": {
-      "AppClientSecret": "REPLACE_ME",
+      "AppClientSecret": "REPLACE_ME - or leave this value blank if AppClient does not use a client secret.",
       "AppClientId": "REPLACE_ME",
       "PoolId": "REPLACE_ME",
       "Region": "REPLACE_ME"

--- a/app/src/main/res/raw/awsconfiguration.json
+++ b/app/src/main/res/raw/awsconfiguration.json
@@ -13,7 +13,7 @@
   },
   "CognitoUserPool": {
     "Default": {
-      "AppClientSecret": "REPLACE_ME - or leave this value blank if AppClient does not use a client secret.",
+      "AppClientSecret": "REPLACE_ME - or remove this line if AppClient does not use a client secret.",
       "AppClientId": "REPLACE_ME",
       "PoolId": "REPLACE_ME",
       "Region": "REPLACE_ME"


### PR DESCRIPTION
Explicitly instruct the user with how to enter Cognito app client secret into _awsconfiguration.json_ when the app client is not configured to use a secret. This will clear up confusion which may arise due to the KVS WebRTC iOS SDK requiring the whole `AppClientSecret` JSON property be removed in _awsconfiguration.json_ for such a case while here in the Android app, it can be either set to an empty string or completely removed.

This is especially helpful considering that the default value for "Client secret" when creating an app client on the AWS console is "Don't generate a client secret".

<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
