### PR TITLE
Dual-Stack Endpoint Support

### DIFF
--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -13,6 +13,7 @@ import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurat
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_STREAM_ARN;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_WEBRTC_ENDPOINT;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_WSS_ENDPOINT;
+import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_USE_DUAL_STACK_ENDPOINTS;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
@@ -157,6 +158,7 @@ public class WebRtcActivity extends AppCompatActivity {
     private String mClientId;
 
     private String webrtcEndpoint;
+    private boolean useDualStackEndpoints;
     private String mStreamArn;
 
     private String mWssEndpoint;
@@ -575,6 +577,7 @@ public class WebRtcActivity extends AppCompatActivity {
         mStreamArn = intent.getStringExtra(KEY_STREAM_ARN);
         mWssEndpoint = intent.getStringExtra(KEY_WSS_ENDPOINT);
         webrtcEndpoint = intent.getStringExtra(KEY_WEBRTC_ENDPOINT);
+        useDualStackEndpoints = intent.getBooleanExtra(KEY_USE_DUAL_STACK_ENDPOINTS, false);
 
         mClientId = intent.getStringExtra(KEY_CLIENT_ID);
         // If no client identifier is present, a random one will be created.
@@ -595,8 +598,16 @@ public class WebRtcActivity extends AppCompatActivity {
 
         //TODO: add ui to control TURN only option
 
+        String stunDomain = useDualStackEndpoints
+                ? "api.aws"
+                : "amazonaws.com";
+        String stunUrl = String.format(
+                "stun:stun.kinesisvideo.%s.%s:443",
+                mRegion,
+                stunDomain
+        );
         final IceServer stun = IceServer
-                .builder(String.format("stun:stun.kinesisvideo.%s.amazonaws.com:443", mRegion))
+                .builder(stunUrl)
                 .createIceServer();
 
         peerIceServers.add(stun);

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -331,7 +331,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
 
             // Check for dual-stack checkbox.
             if (mUseDualStackEndpoints.isChecked()) {
-                awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));
+                awsKinesisVideoClient.setEndpoint(KvsClientFactory.generateDualStackEndpoint(region));
             }
         }
         return awsKinesisVideoClient;

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.Switch;
 import android.widget.CheckedTextView;
 import android.widget.EditText;
 import android.widget.ListView;
@@ -94,7 +95,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
     private EditText mClientId;
     private EditText mRegion;
     private Spinner mCameras;
-    private CheckBox mUseDualStackEndpoints;
+    private Switch mUseDualStackEndpoints;
     private CheckBox mIngestMedia;
     private final List<ResourceEndpointListItem> mEndpointList = new ArrayList<>();
     private final List<IceServer> mIceServerList = new ArrayList<>();

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -74,6 +74,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
     public static final String KEY_ICE_SERVER_TTL = "iceServerTTL";
     public static final String KEY_ICE_SERVER_URI = "iceServerUri";
     public static final String KEY_CAMERA_FRONT_FACING = "cameraFrontFacing";
+    public static final String KEY_USE_DUAL_STACK_ENDPOINTS = "useDualStackEndpoints";
 
     public static final String KEY_SEND_VIDEO = "sendVideo";
     public static final String KEY_SEND_AUDIO = "sendAudio";
@@ -272,6 +273,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         extras.putString(KEY_CHANNEL_ARN, mChannelArn);
         extras.putString(KEY_STREAM_ARN, mStreamArn);
         extras.putBoolean(KEY_IS_MASTER, isMaster);
+        extras.putBoolean(KEY_USE_DUAL_STACK_ENDPOINTS, mUseDualStackEndpoints.isChecked());
 
         if (!mIceServerList.isEmpty()) {
             ArrayList<String> userNames = new ArrayList<>(mIceServerList.size());
@@ -498,6 +500,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
             //         client is just used for getting ICE servers, not for actual signaling.
             // Step 6. Call GetIceServerConfig in order to obtain TURN ICE server info.
             //         Note: the STUN endpoint will be `stun:stun.kinesisvideo.${region}.amazonaws.com:443`
+            //         for legacy mode and `stun:stun.kinesisvideo.${region}.api.aws:443` for dual-stack mode.
             try {
                 final AWSKinesisVideoSignalingClient awsKinesisVideoSignalingClient = mFragment.get().getAwsKinesisVideoSignalingClient(region, dataEndpoint);
                 GetIceServerConfigResult getIceServerConfigResult = awsKinesisVideoSignalingClient.getIceServerConfig(

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -315,28 +315,6 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         return extras;
     }
 
-    private AWSKinesisVideoClient getAwsKinesisVideoClient(final String region) {
-        final AWSKinesisVideoClient awsKinesisVideoClient = new AWSKinesisVideoClient(
-                KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
-        awsKinesisVideoClient.setRegion(Region.getRegion(region));
-        awsKinesisVideoClient.setSignerRegionOverride(region);
-        awsKinesisVideoClient.setServiceNameIntern("kinesisvideo");
-        try {
-            String customEndpoint = BuildConfig.CONTROL_PLANE_URI;
-            if (customEndpoint != null && !customEndpoint.isEmpty() && !"null".equals(customEndpoint)) {
-                awsKinesisVideoClient.setEndpoint(customEndpoint);
-            }
-        } catch (Exception e) {
-            // CONTROL_PLANE_URI not defined in .env
-
-            // Check for dual-stack checkbox.
-            if (mUseDualStackEndpoints.isChecked()) {
-                awsKinesisVideoClient.setEndpoint(KvsClientFactory.generateDualStackEndpoint(region));
-            }
-        }
-        return awsKinesisVideoClient;
-    }
-
     private AWSKinesisVideoSignalingClient getAwsKinesisVideoSignalingClient(final String region, final String endpoint) {
         final AWSKinesisVideoSignalingClient client = new AWSKinesisVideoSignalingClient(
                 KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -86,11 +86,15 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
             KEY_SEND_AUDIO,
     };
 
+    public static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT = "kinesisvideo.%s.api.aws";
+    public static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
+
 
     private EditText mChannelName;
     private EditText mClientId;
     private EditText mRegion;
     private Spinner mCameras;
+    private CheckBox mUseDualStackEndpoints;
     private CheckBox mIngestMedia;
     private final List<ResourceEndpointListItem> mEndpointList = new ArrayList<>();
     private final List<IceServer> mIceServerList = new ArrayList<>();
@@ -132,6 +136,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         mChannelName = view.findViewById(R.id.channel_name);
         mClientId = view.findViewById(R.id.client_id);
         mRegion = view.findViewById(R.id.region);
+        mUseDualStackEndpoints = view.findViewById(R.id.use_dual_stack_endpoints);
         mIngestMedia = view.findViewById(R.id.ingest_media);
         setRegionFromCognito();
 
@@ -175,7 +180,18 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         }
     }
 
+    private String generateDualStackEndpoint(String region) {
+        if (region == null || region.isEmpty()) {
+            Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
+            return null;
+        }
 
+        if (region.startsWith("cn-")) {
+            return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN, region);
+        }
+
+        return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT, region);
+    }
 
     private View.OnClickListener startMasterActivityWhenClicked() {
         return new View.OnClickListener() {
@@ -321,8 +337,12 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
             }
         } catch (Exception e) {
             // CONTROL_PLANE_URI not defined in .env
+
+            // Check for dual-stack checkbox.
+            if (mUseDualStackEndpoints.isChecked()) {
+                awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));
+            }
         }
-        
         return awsKinesisVideoClient;
     }
 

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -50,6 +50,7 @@ import com.amazonaws.services.kinesisvideosignaling.AWSKinesisVideoSignalingClie
 import com.amazonaws.services.kinesisvideosignaling.model.GetIceServerConfigRequest;
 import com.amazonaws.services.kinesisvideosignaling.model.GetIceServerConfigResult;
 import com.amazonaws.services.kinesisvideosignaling.model.IceServer;
+import com.amazonaws.kinesisvideo.demoapp.util.KvsClientFactory;
 
 
 import java.lang.ref.WeakReference;
@@ -179,19 +180,6 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         if (region != null) {
             mRegion.setText(region);
         }
-    }
-
-    private String generateDualStackEndpoint(String region) {
-        if (region == null || region.isEmpty()) {
-            Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
-            return null;
-        }
-
-        if (region.startsWith("cn-")) {
-            return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN, region);
-        }
-
-        return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT, region);
     }
 
     private View.OnClickListener startMasterActivityWhenClicked() {
@@ -416,7 +404,8 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
             // Step 1. Create Kinesis Video Client
             final AWSKinesisVideoClient awsKinesisVideoClient;
             try {
-                awsKinesisVideoClient = mFragment.get().getAwsKinesisVideoClient(region);
+                final boolean useDualStack = mFragment.get().mUseDualStackEndpoints.isChecked();
+                awsKinesisVideoClient = KvsClientFactory.getAwsKinesisVideoClient(region, useDualStack);
             } catch (Exception e) {
                 return "Create client failed with " + e.getLocalizedMessage();
             }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -12,6 +12,7 @@ public class KvsClientFactory {
 
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT = "kinesisvideo.%s.api.aws";
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
+    private static final String KVS_SERVICE_NAME = "kinesisvideo";
 
     private static String generateDualStackEndpoint(final String region) {
         if (region == null || region.isEmpty()) {
@@ -31,7 +32,7 @@ public class KvsClientFactory {
                 KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
         awsKinesisVideoClient.setRegion(Region.getRegion(region));
         awsKinesisVideoClient.setSignerRegionOverride(region);
-        awsKinesisVideoClient.setServiceNameIntern("kinesisvideo");
+        awsKinesisVideoClient.setServiceNameIntern(KVS_SERVICE_NAME);
 
         if (useDualStack) {
             awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -1,0 +1,43 @@
+package com.amazonaws.kinesisvideo.demoapp.util;
+
+import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
+import com.amazonaws.services.kinesisvideo.AWSKinesisVideoClient;
+import com.amazonaws.regions.Region;
+
+import android.util.Log;
+
+
+public class KvsClientFactory {
+    private static final String TAG = KvsClientFactory.class.getSimpleName();
+
+    private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT = "kinesisvideo.%s.api.aws";
+    private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
+
+    private static String generateDualStackEndpoint(String region) {
+        if (region == null || region.isEmpty()) {
+            Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
+            return null;
+        }
+
+        if (region.startsWith("cn-")) {
+            return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN, region);
+        }
+
+        return String.format(DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT, region);
+    }
+    
+    public static AWSKinesisVideoClient getAwsKinesisVideoClient(final String region, final boolean useDualStack) {
+        final AWSKinesisVideoClient awsKinesisVideoClient = new AWSKinesisVideoClient(
+                KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
+        awsKinesisVideoClient.setRegion(Region.getRegion(region));
+        awsKinesisVideoClient.setSignerRegionOverride(region);
+        awsKinesisVideoClient.setServiceNameIntern("kinesisvideo");
+
+        if (useDualStack) {
+            awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));
+        }
+
+        return awsKinesisVideoClient;
+    }
+    
+}

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -13,7 +13,7 @@ public class KvsClientFactory {
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT = "kinesisvideo.%s.api.aws";
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
 
-    private static String generateDualStackEndpoint(String region) {
+    private static String generateDualStackEndpoint(final String region) {
         if (region == null || region.isEmpty()) {
             Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
             return null;

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -14,7 +14,7 @@ public class KvsClientFactory {
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
     private static final String KVS_SERVICE_NAME = "kinesisvideo";
 
-    public static String generateDualStackEndpoint(final String region) {
+    private static String generateDualStackEndpoint(final String region) {
         if (region == null || region.isEmpty()) {
             Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
             return null;

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -3,6 +3,7 @@ package com.amazonaws.kinesisvideo.demoapp.util;
 import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
 import com.amazonaws.services.kinesisvideo.AWSKinesisVideoClient;
 import com.amazonaws.regions.Region;
+import com.amazonaws.kinesisvideo.demoapp.BuildConfig;
 
 import android.util.Log;
 

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -14,7 +14,7 @@ public class KvsClientFactory {
     private static final String DUAL_STACK_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
     private static final String KVS_SERVICE_NAME = "kinesisvideo";
 
-    private static String generateDualStackEndpoint(final String region) {
+    public static String generateDualStackEndpoint(final String region) {
         if (region == null || region.isEmpty()) {
             Log.w(TAG, "AWS region is null or empty, will use legacy control-plane endpoint.");
             return null;

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/util/KvsClientFactory.java
@@ -34,8 +34,20 @@ public class KvsClientFactory {
         awsKinesisVideoClient.setSignerRegionOverride(region);
         awsKinesisVideoClient.setServiceNameIntern(KVS_SERVICE_NAME);
 
-        if (useDualStack) {
-            awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));
+        boolean isCustomEndpointSet = false;
+        try {
+            String customEndpoint = BuildConfig.CONTROL_PLANE_URI;
+            if (customEndpoint != null && !customEndpoint.isEmpty() && !"null".equals(customEndpoint)) {
+                awsKinesisVideoClient.setEndpoint(customEndpoint);
+                isCustomEndpointSet = true;
+            }
+        } catch (Exception e) {
+        }
+
+        if (!isCustomEndpointSet) {
+            if (useDualStack) {
+                awsKinesisVideoClient.setEndpoint(generateDualStackEndpoint(region));
+            }
         }
 
         return awsKinesisVideoClient;

--- a/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -70,6 +70,16 @@
             tools:ignore="Autofill,HardcodedText"
             android:inputType="text" />
 
+        <CheckBox
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Use dual-stack endpoints"
+            android:layoutDirection="rtl"
+            android:id="@+id/use_dual_stack_endpoints"
+            android:layout_margin="16dp"
+            android:textSize="16sp"
+            tools:ignore="HardcodedText" />
+
         <Space
             android:layout_width="match_parent"
             android:layout_height="20dp" />

--- a/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -70,15 +70,46 @@
             tools:ignore="Autofill,HardcodedText"
             android:inputType="text" />
 
-        <CheckBox
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="KVS Endpoint Type"
+            tools:ignore="HardcodedText" />
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Use dual-stack endpoints"
-            android:layoutDirection="rtl"
-            android:id="@+id/use_dual_stack_endpoints"
-            android:layout_margin="16dp"
-            android:textSize="16sp"
-            tools:ignore="HardcodedText" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginStart="20dp">
+
+            <TextView
+                android:id="@+id/label_ipv4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="IPv4"
+                android:textSize="16sp"
+                android:layout_marginEnd="8dp" />
+
+            <Switch
+                android:id="@+id/use_dual_stack_endpoints"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/label_dual_stack"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Dual-stack"
+                android:textSize="16sp"
+                android:layout_marginStart="4dp" />
+
+        </LinearLayout>
+
 
         <Space
             android:layout_width="match_parent"
@@ -93,7 +124,8 @@
         <Spinner
             android:layout_width="match_parent"
             android:layout_height="20dp"
-            android:id="@+id/camera_spinner" />
+            android:id="@+id/camera_spinner"
+            android:layout_marginStart="10dp" />
 
         <Space
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -88,25 +88,18 @@
             android:layout_marginStart="20dp">
 
             <TextView
-                android:id="@+id/label_ipv4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="IPv4"
-                android:textSize="16sp"
-                android:layout_marginEnd="8dp" />
-
-            <Switch
-                android:id="@+id/use_dual_stack_endpoints"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-            <TextView
                 android:id="@+id/label_dual_stack"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Dual-stack"
                 android:textSize="16sp"
-                android:layout_marginStart="4dp" />
+                android:layout_marginStart="0dp" />
+
+            <Switch
+                android:id="@+id/use_dual_stack_endpoints"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp" />
 
         </LinearLayout>
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Added a switch to the UI to control whether to use dual-stack KVS endpoints.
- Tested e2e WebRTC connection using pre-prod dual-stack control plane endpoints with JS Test Page as the other peer.
- Improved margin alignment between existing UI components.

<img src="https://github.com/user-attachments/assets/d5d0ce64-720a-4646-9998-457811549928" width="400">


<br>
<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
