### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
     branches:
       - master
+      - develop
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,33 @@ Once login is successful, you will entering the following channel information to
   * Start the web browser using the [Javascript SDK](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js) and start it as `viewer`.
   * Verify media showing up from the Android device to the browser.
 
-## 6. ICE Candidate Trickling
+## 6. WebRTC Ingestion support
+
+The sample application demonstrates how to connect to the KVS WebRTC storage session as a master or viewer participant.
+
+For more information about WebRTC ingestion, see https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html.
+
+  ### 6.1 Setting up signaling channel and stream
+
+Follow the instructions below to:
+1. Create the signaling channel: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/ingestion-create-channel.html
+2. Create the stream: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/ingestion-create-stream.html
+3. Link the signaling channel and stream: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/configure-ingestion.html
+4. Configure the IAM role with the correct permissions: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/ingestion-grant-permission.html
+
+  ### 6.2 Prerequisites
+
+* Ensure H.264 and OPUS codec support is available on the device
+
+Usage:
+  1. Master with Ingest Media: Check the "Ingest Media" option and ensure both "Send Audio" and "Send Video" are selected. The master will stream audio and video to the KVS WebRTC storage session, who forwards it to all connected viewer participants and the configured Kinesis Video stream.
+
+  2. Viewer with Ingest Media: Check the "Ingest Media" option but only select "Send Audio" (video must be deselected). Multiple viewer participants (at most three) can connect to the same channel and their optional audio will be incorporated into the Kinesis Video stream, forwarded to the master participant, and forwarded to all other viewer participants.
+
+> [!NOTE]
+> Android emulators may not have H.264 encoding support. A pop-up error will appear if the device you're using does not have H.264 encoding support for master participants or H.264 decoding support for viewer participants.
+
+## 7. ICE Candidate Trickling
 
 Candidate trickling is a technique through which a caller may incrementally provide candidates to the callee after the initial offer has been dispatched; the semantics of "Trickle ICE" are defined in [RFC8838].
 
@@ -100,7 +126,7 @@ However, in the case that it needs to be disabled, locate the RTCConfiguration p
 PeerConnection.RTCConfiguration rtcConfig = new PeerConnection.RTCConfiguration();
 rtcConfig.continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY;
 ```
-## 7. Testing
+## 8. Testing
 This SDK has been tested with Java 11, 17 to build the Gradle dependencies and Java 8, 11, and, 17 in the compile options in build.gradle
 
 ```agsl

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,37 @@ android {
         versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        
+        // Load .env file and set BuildConfig fields
+        def envFile = rootProject.file('.env')
+        def envFields = [:]
+        if (envFile.exists()) {
+            envFile.readLines().each {
+                def (key, value) = it.tokenize('=')
+                if (key && value) {
+                    envFields[key] = value
+                    buildConfigField "String", key, "\"${value}\""
+                }
+            }
+        }
+        
+        // Set default null values for missing fields
+        if (!envFields.containsKey('CONTROL_PLANE_URI')) {
+            buildConfigField "String", "CONTROL_PLANE_URI", "null"
+        }
+        if (!envFields.containsKey('AWS_ACCESS_KEY_ID')) {
+            buildConfigField "String", "AWS_ACCESS_KEY_ID", "null"
+        }
+        if (!envFields.containsKey('AWS_SECRET_ACCESS_KEY')) {
+            buildConfigField "String", "AWS_SECRET_ACCESS_KEY", "null"
+        }
+        if (!envFields.containsKey('AWS_SESSION_TOKEN')) {
+            buildConfigField "String", "AWS_SESSION_TOKEN", "null"
+        }
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdk 29
         targetSdk 33
         versionCode 1
-        versionName "1.1.0"
+        versionName "1.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
 
-    def aws_version = '2.75.0'
+    def aws_version = '2.81.1'
     implementation("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
     implementation("com.amazonaws:aws-android-sdk-kinesisvideo-signaling:$aws_version@aar") { transitive = true }
     implementation("com.amazonaws:aws-android-sdk-kinesisvideo-webrtcstorage:$aws_version@aar") { transitive = true }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoWebRtcDemoApp.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoWebRtcDemoApp.java
@@ -3,7 +3,10 @@ package com.amazonaws.kinesisvideo.demoapp;
 import android.app.Application;
 import android.util.Log;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.config.AWSConfiguration;
 
@@ -14,30 +17,89 @@ public class KinesisVideoWebRtcDemoApp extends Application {
     private static final String TAG = KinesisVideoWebRtcDemoApp.class.getSimpleName();
 
     public static AWSCredentialsProvider getCredentialsProvider() {
+        // Check if custom credentials are available from .env
+        if (hasEnvCredentials()) {
+            return new CustomCredentialsProvider();
+        }
         return AWSMobileClient.getInstance();
+    }
+
+    public static boolean hasEnvCredentials() {
+        try {
+            String accessKeyId = BuildConfig.AWS_ACCESS_KEY_ID;
+            String secretAccessKey = BuildConfig.AWS_SECRET_ACCESS_KEY;
+            return accessKeyId != null && !accessKeyId.isEmpty() && !"null".equals(accessKeyId) &&
+                   secretAccessKey != null && !secretAccessKey.isEmpty() && !"null".equals(secretAccessKey);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static class CustomCredentialsProvider implements AWSCredentialsProvider {
+        @Override
+        public AWSCredentials getCredentials() {
+            try {
+                String accessKeyId = BuildConfig.AWS_ACCESS_KEY_ID;
+                String secretAccessKey = BuildConfig.AWS_SECRET_ACCESS_KEY;
+                String sessionToken = BuildConfig.AWS_SESSION_TOKEN;
+                
+                if (!hasEnvCredentials()) {
+                    throw new RuntimeException("AWS credentials not available from .env");
+                }
+                
+                if (sessionToken != null && !sessionToken.isEmpty() && !"null".equals(sessionToken)) {
+                    return new BasicSessionCredentials(accessKeyId, secretAccessKey, sessionToken);
+                } else {
+                    return new BasicAWSCredentials(accessKeyId, secretAccessKey);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to get credentials from .env: " + e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public void refresh() {
+            // No-op for static credentials
+        }
     }
 
     /**
      * Parse awsconfiguration.json and extract the region from it.
+     * If using .env credentials, return a null region.
      *
      * @return The region in String form. {@code null} if not.
      * @throws IllegalStateException if awsconfiguration.json is not properly configured.
      */
     public static String getRegion() {
-        final AWSConfiguration configuration = AWSMobileClient.getInstance().getConfiguration();
-        if (configuration == null) {
-            throw new IllegalStateException("awsconfiguration.json has not been properly configured!");
+        // If using .env credentials, return null (user will manually enter region)
+        if (hasEnvCredentials()) {
+            return null;
         }
-
-        final JSONObject jsonObject = configuration.optJsonObject("CredentialsProvider");
-
-        String region = null;
+        
         try {
-            region = (String) ((JSONObject) (((JSONObject) jsonObject.get("CognitoIdentity")).get("Default"))).get("Region");
-        } catch (final JSONException e) {
-            Log.e(TAG, "Got exception when extracting region from cognito setting.", e);
+            final AWSConfiguration configuration = AWSMobileClient.getInstance().getConfiguration();
+            if (configuration == null) {
+                Log.w(TAG, "awsconfiguration.json not found, returning null region");
+                return null; // Return null instead of throwing exception
+            }
+
+            final JSONObject jsonObject = configuration.optJsonObject("CredentialsProvider");
+            if (jsonObject == null) {
+                Log.w(TAG, "CredentialsProvider not found in awsconfiguration.json");
+                return null;
+            }
+
+            String region = null;
+            try {
+                region = (String) ((JSONObject) (((JSONObject) jsonObject.get("CognitoIdentity")).get("Default"))).get("Region");
+            } catch (final JSONException e) {
+                Log.e(TAG, "Got exception when extracting region from cognito setting.", e);
+            }
+            return region;
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to get region from awsconfiguration.json: " + e.getMessage());
+            return null; // Return null on any error
         }
-        return region;
     }
 
 }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/SimpleNavActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/SimpleNavActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
 
+import com.amazonaws.kinesisvideo.demoapp.BuildConfig;
+import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -46,6 +48,11 @@ public class SimpleNavActivity extends AppCompatActivity
 
         NavigationView navigationView = findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
+        
+        // Disable logout menu item if using credentials from .env file
+        if (KinesisVideoWebRtcDemoApp.hasEnvCredentials()) {
+            navigationView.getMenu().findItem(R.id.nav_logout).setEnabled(false);
+        }
 
         if (savedInstanceState != null) {
             streamFragment = getSupportFragmentManager().findFragmentByTag(StreamWebRtcConfigurationFragment.class.getName());
@@ -70,6 +77,11 @@ public class SimpleNavActivity extends AppCompatActivity
         int id = item.getItemId();
 
         if (id == R.id.nav_logout) {
+            if (KinesisVideoWebRtcDemoApp.hasEnvCredentials()) {
+                Log.i(TAG, "Logout disabled when using credentials from .env file");
+                return true;
+            }
+            
             AWSMobileClient.getInstance().signOut();
             AWSMobileClient.getInstance().showSignIn(this,
                     SignInUIOptions.builder()
@@ -111,4 +123,6 @@ public class SimpleNavActivity extends AppCompatActivity
             e.printStackTrace();
         }
     }
+    
+
 }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/StartUpActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/StartUpActivity.java
@@ -8,6 +8,8 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.amazonaws.kinesisvideo.demoapp.BuildConfig;
+import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
 import com.amazonaws.kinesisvideo.demoapp.R;
 import com.amazonaws.kinesisvideo.demoapp.util.ActivityUtils;
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -31,7 +33,16 @@ public class StartUpActivity extends AppCompatActivity {
         supportFinishAfterTransition();
 
         AsyncTask.execute(() -> {
-            if (auth.isSignedIn()) {
+            // Check if custom credentials are available in .env
+            boolean hasEnvSetting = KinesisVideoWebRtcDemoApp.hasEnvCredentials();
+            
+            if (hasEnvSetting || auth.isSignedIn()) {
+                Log.i(TAG, hasEnvSetting ? "Using credentials from environmental seetting" : "User already signed in");
+                
+                if (hasEnvSetting) {
+                    showCredentialsWarning();
+                }
+                
                 ActivityUtils.startActivity(thisActivity, SimpleNavActivity.class);
             } else {
                 auth.showSignIn(thisActivity,
@@ -78,5 +89,9 @@ public class StartUpActivity extends AppCompatActivity {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+    }
+    
+    private void showCredentialsWarning() {
+        Log.w(TAG, "WARNING: Using environment settings - please follow standard AWS recommended practices for production (https://docs.aws.amazon.com/cognito/)");
     }
 }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -679,6 +679,11 @@ public class WebRtcActivity extends AppCompatActivity {
             localView.init(rootEglBase.getEglBaseContext(), null);
         }
 
+        // Hide local view if not sending video
+        if (!isVideoSent) {
+            localView.setVisibility(View.GONE);
+        }
+
         if (isAudioSent) {
             AudioSource audioSource = peerConnectionFactory.createAudioSource(new MediaConstraints());
             localAudioTrack = peerConnectionFactory.createAudioTrack(AudioTrackID, audioSource);
@@ -696,6 +701,11 @@ public class WebRtcActivity extends AppCompatActivity {
 
         dataChannelText = findViewById(R.id.data_channel_text);
         sendDataChannelButton = findViewById(R.id.send_data_channel_text);
+        // Disable data channel functionality when WebRTC Storage Session is enabled
+        if (isStorageSession()) {
+            dataChannelText.setVisibility(View.GONE);
+            sendDataChannelButton.setVisibility(View.GONE);
+        }
 
         createNotificationChannel();
     }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -9,6 +9,7 @@ import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurat
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_IS_MASTER;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_REGION;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_SEND_AUDIO;
+import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_SEND_VIDEO;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_STREAM_ARN;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_WEBRTC_ENDPOINT;
 import static com.amazonaws.kinesisvideo.demoapp.fragment.StreamWebRtcConfigurationFragment.KEY_WSS_ENDPOINT;
@@ -36,6 +37,7 @@ import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
@@ -56,6 +58,7 @@ import com.amazonaws.kinesisvideo.webrtc.KinesisVideoSdpObserver;
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.kinesisvideowebrtcstorage.AWSKinesisVideoWebRTCStorageClient;
 import com.amazonaws.services.kinesisvideowebrtcstorage.model.JoinStorageSessionRequest;
+import com.amazonaws.services.kinesisvideowebrtcstorage.model.JoinStorageSessionAsViewerRequest;
 import com.google.common.base.Strings;
 
 import org.webrtc.AudioSource;
@@ -137,6 +140,7 @@ public class WebRtcActivity extends AppCompatActivity {
     private final List<IceServer> peerIceServers = new ArrayList<>();
 
     private boolean gotException = false;
+    private boolean codecValidationFailed = false;
 
     private String recipientClientId;
 
@@ -144,6 +148,7 @@ public class WebRtcActivity extends AppCompatActivity {
 
     private boolean master = true;
     private boolean isAudioSent = false;
+    private boolean isVideoSent = false; //See https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_webrtc_JoinStorageSessionAsViewer.html
 
     private EditText dataChannelText = null;
     private Button sendDataChannelButton = null;
@@ -202,7 +207,8 @@ public class WebRtcActivity extends AppCompatActivity {
             return;
         }
 
-        if (master) {
+        if (master || isStorageSession()) {
+            // Create peer connection for masters and viewers using storage session
             createLocalPeerConnection();
         }
 
@@ -215,16 +221,13 @@ public class WebRtcActivity extends AppCompatActivity {
             @Override
             public void onSdpOffer(final Event offerEvent) {
                 Log.d(TAG, "Received SDP Offer: Setting Remote Description ");
-
                 final String sdp = Event.parseOfferEvent(offerEvent);
-
                 localPeer.setRemoteDescription(new KinesisVideoSdpObserver(), new SessionDescription(SessionDescription.Type.OFFER, sdp));
                 recipientClientId = offerEvent.getSenderClientId();
                 Log.d(TAG, "Received SDP offer for client ID: " + recipientClientId + ". Creating answer");
-
                 createSdpAnswer();
 
-                if (master && webrtcEndpoint != null) {
+                if (master && isStorageSession()) {
                     runOnUiThread(() -> Toast.makeText(getApplicationContext(), "Media is being recorded to " + mStreamArn, Toast.LENGTH_LONG).show());
                     Log.i(TAG, "Media is being recorded to " + mStreamArn);
                 }
@@ -232,24 +235,16 @@ public class WebRtcActivity extends AppCompatActivity {
 
             @Override
             public void onSdpAnswer(final Event answerEvent) {
-
                 Log.d(TAG, "SDP answer received from signaling");
-
                 final String sdp = Event.parseSdpEvent(answerEvent);
-
                 final SessionDescription sdpAnswer = new SessionDescription(SessionDescription.Type.ANSWER, sdp);
 
-                localPeer.setRemoteDescription(new KinesisVideoSdpObserver() {
-                    @Override
-                    public void onCreateFailure(final String error) {
-                        super.onCreateFailure(error);
-                    }
-                }, sdpAnswer);
-                Log.d(TAG, "Answer Client ID: " + answerEvent.getSenderClientId());
-                peerConnectionFoundMap.put(answerEvent.getSenderClientId(), localPeer);
-                // Check if ICE candidates are available in the queue and add the candidate
-                handlePendingIceCandidates(answerEvent.getSenderClientId());
-
+                localPeer.setRemoteDescription(new KinesisVideoSdpObserver(), sdpAnswer);
+                
+                String answerClientId = answerEvent.getSenderClientId();
+                Log.d(TAG, "Answer Client ID: " + answerClientId);
+                peerConnectionFoundMap.put(answerClientId, localPeer);
+                handlePendingIceCandidates(answerClientId);
             }
 
             @Override
@@ -293,34 +288,31 @@ public class WebRtcActivity extends AppCompatActivity {
 
             Log.d(TAG, "Client connected to Signaling service " + client.isOpen());
 
-            if (master) {
-
-                // If webrtc endpoint is non-null ==> Ingest media was checked
-                if (webrtcEndpoint != null) {
-                    new Thread(() -> {
-                        try {
-                            final AWSKinesisVideoWebRTCStorageClient storageClient =
-                                    new AWSKinesisVideoWebRTCStorageClient(
-                                            KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
-                            storageClient.setRegion(Region.getRegion(mRegion));
-                            storageClient.setSignerRegionOverride(mRegion);
-                            storageClient.setServiceNameIntern("kinesisvideo");
-                            storageClient.setEndpoint(webrtcEndpoint);
-
-                            Log.i(TAG, "Channel ARN is: " + mChannelArn);
-                            storageClient.joinStorageSession(new JoinStorageSessionRequest()
-                                    .withChannelArn(mChannelArn));
-                            Log.i(TAG, "Join storage session request sent!");
-                        } catch (Exception ex) {
-                            Log.e(TAG, "Error sending join storage session request!", ex);
-                        }
-                    }).start();
+            // If webrtc endpoint is non-null ==> Ingest media was checked
+            if (isStorageSession()) {
+                new Thread(() -> {
+                    try {
+                        final AWSKinesisVideoWebRTCStorageClient storageClient =
+                                new AWSKinesisVideoWebRTCStorageClient(
+                                        KinesisVideoWebRtcDemoApp.getCredentialsProvider().getCredentials());
+                        configureStorageClient(storageClient);
+                        joinStorageSession(storageClient);
+                    } catch (Exception ex) {
+                        Log.e(TAG, "Error sending join storage session request!", ex);
+                    }
+                }).start();
+            }
+            
+            if (!master) {
+                // Only create SDP offer for Viewer participant without storage
+                if (!isStorageSession()) {
+                    Log.d(TAG, "Signaling service is connected: " +
+                            "Sending offer as P2P viewer"); // Direct viewer
+                    createSdpOffer();
+                } else {
+                    Log.d(TAG, "Multi-viewer participant: Waiting for offer from storage agent");
+                    // Storage agent will send the offer, viewer just waits
                 }
-            } else {
-                Log.d(TAG, "Signaling service is connected: " +
-                        "Sending offer as viewer to remote peer"); // Viewer
-
-                createSdpOffer();
             }
         } else {
             Log.e(TAG, "Error in connecting to signaling service");
@@ -330,6 +322,94 @@ public class WebRtcActivity extends AppCompatActivity {
 
     private boolean isValidClient() {
         return client != null && client.isOpen();
+    }
+
+    private void configureStorageClient(final AWSKinesisVideoWebRTCStorageClient storageClient) {
+        storageClient.setRegion(Region.getRegion(mRegion));
+        storageClient.setSignerRegionOverride(mRegion);
+        storageClient.setServiceNameIntern("kinesisvideo");
+        storageClient.setEndpoint(webrtcEndpoint);
+    }
+
+    private void joinStorageSession(AWSKinesisVideoWebRTCStorageClient storageClient) {
+        if (master) {
+            joinAsMaster(storageClient);
+        } else {
+            joinAsViewer(storageClient);
+        }
+    }
+
+    private void joinAsMaster(AWSKinesisVideoWebRTCStorageClient storageClient) {
+        JoinStorageSessionRequest request = new JoinStorageSessionRequest()
+                .withChannelArn(mChannelArn);
+        storageClient.joinStorageSession(request);
+        Log.i(TAG, "Master: Join storage session request sent for channel: " + mChannelArn);
+    }
+
+    private void joinAsViewer(AWSKinesisVideoWebRTCStorageClient storageClient) {
+        JoinStorageSessionAsViewerRequest request = new JoinStorageSessionAsViewerRequest()
+                .withChannelArn(mChannelArn)
+                .withClientId(mClientId);
+        storageClient.joinStorageSessionAsViewer(request);
+        Log.i(TAG, "Viewer: Join storage session request sent for channel: " + mChannelArn);
+    }
+
+    private boolean isStorageViewer() {
+        return !master && webrtcEndpoint != null;
+    }
+
+    private boolean isStorageSession() {
+        return webrtcEndpoint != null;
+    }
+    
+    private boolean checkCodecSupport() {
+        // Need to create temporary EglBase for codec checking
+        final EglBase tempEglBase = EglBase.create();
+        
+        final VideoDecoderFactory vdf = new DefaultVideoDecoderFactory(tempEglBase.getEglBaseContext());
+        boolean hasH264Decoder = false;
+        for (final VideoCodecInfo videoCodecInfo : vdf.getSupportedCodecs()) {
+            if ("H264".equalsIgnoreCase(videoCodecInfo.name)) {
+                hasH264Decoder = true;
+                break;
+            }
+        }
+        
+        final VideoEncoderFactory vef = new DefaultVideoEncoderFactory(tempEglBase.getEglBaseContext(),
+                ENABLE_INTEL_VP8_ENCODER, ENABLE_H264_HIGH_PROFILE);
+        boolean hasH264Encoder = false;
+        for (final VideoCodecInfo videoCodecInfo : vef.getSupportedCodecs()) {
+            if ("H264".equalsIgnoreCase(videoCodecInfo.name)) {
+                hasH264Encoder = true;
+                break;
+            }
+        }
+        
+        tempEglBase.release();
+        
+        // Check H.264 encoder support for master with ingest media
+        if (master && isStorageSession() && !hasH264Encoder) {
+            codecValidationFailed = true;
+            new AlertDialog.Builder(this)
+                    .setTitle("Codec Not Supported")
+                    .setMessage("This device does not have H.264 encoder support required for WebRTC ingestion.")
+                    .setPositiveButton("OK", (dialog, which) -> finish())
+                    .show();
+            return true;
+        }
+        
+        // Check H.264 decoder support for viewer with storage session
+        if (isStorageViewer() && !hasH264Decoder) {
+            codecValidationFailed = true;
+            new AlertDialog.Builder(this)
+                    .setTitle("Codec Not Supported")
+                    .setMessage("This device does not have H.264 decoder support required for WebRTC ingestion.")
+                    .setPositiveButton("OK", (dialog, which) -> finish())
+                    .show();
+            return true;
+        }
+        
+        return false; // Codec supported, continue
     }
 
     /**
@@ -344,49 +424,48 @@ public class WebRtcActivity extends AppCompatActivity {
         // Add any pending ICE candidates from the queue for the client ID
         Log.d(TAG, "Pending ice candidates found? " + pendingIceCandidatesMap.get(clientId));
         final Queue<IceCandidate> pendingIceCandidatesQueueByClientId = pendingIceCandidatesMap.get(clientId);
+        
         while (pendingIceCandidatesQueueByClientId != null && !pendingIceCandidatesQueueByClientId.isEmpty()) {
             final IceCandidate iceCandidate = pendingIceCandidatesQueueByClientId.peek();
             final PeerConnection peer = peerConnectionFoundMap.get(clientId);
+            
             if (peer != null) {
                 final boolean addIce = peer.addIceCandidate(iceCandidate);
                 Log.d(TAG, "Added ice candidate after SDP exchange " + iceCandidate + " " + (addIce ? "Successfully" : "Failed"));
             }
+            // After sending pending ICE candidates, the client ID's peer connection need not be tracked
             pendingIceCandidatesQueueByClientId.remove();
         }
-        // After sending pending ICE candidates, the client ID's peer connection need not be tracked
+        
         pendingIceCandidatesMap.remove(clientId);
     }
 
     private void checkAndAddIceCandidate(final Event message, final IceCandidate iceCandidate) {
         // If answer/offer is not received, it means peer connection is not found. Hold the received ICE candidates in the map.
         // Once the peer connection is found, add them directly instead of adding it to the queue.
-
-        if (!peerConnectionFoundMap.containsKey(message.getSenderClientId())) {
+        String senderClientId = message.getSenderClientId();
+        
+        if (!peerConnectionFoundMap.containsKey(senderClientId)) {
             Log.d(TAG, "SDP exchange is not complete. Ice candidate " + iceCandidate + " + added to pending queue");
 
             // If the entry for the client ID already exists (in case of subsequent ICE candidates), update the queue
             final Queue<IceCandidate> pendingIceCandidatesQueueByClientId;
-            if (pendingIceCandidatesMap.containsKey(message.getSenderClientId())) {
-                pendingIceCandidatesQueueByClientId = pendingIceCandidatesMap.get(message.getSenderClientId());
-            }
-
-            // If the first ICE candidate before peer connection is received, add entry to map and ICE candidate to a queue
-            else {
+            if (pendingIceCandidatesMap.containsKey(senderClientId)) {
+                pendingIceCandidatesQueueByClientId = pendingIceCandidatesMap.get(senderClientId);
+            } else {
                 pendingIceCandidatesQueueByClientId = new LinkedList<>();
             }
 
             if (pendingIceCandidatesQueueByClientId != null) {
                 pendingIceCandidatesQueueByClientId.add(iceCandidate);
-                pendingIceCandidatesMap.put(message.getSenderClientId(), pendingIceCandidatesQueueByClientId);
+                pendingIceCandidatesMap.put(senderClientId, pendingIceCandidatesQueueByClientId);
             }
-        }
-
-        // This is the case where peer connection is established and ICE candidates are received for the established
-        // connection
+        } 
+        // This is the case where peer connection is established and ICE candidates are received for the established connection
         else {
             Log.d(TAG, "Peer connection found already");
             // Remote sent us ICE candidates, add to local peer connection
-            final PeerConnection peer = peerConnectionFoundMap.get(message.getSenderClientId());
+            final PeerConnection peer = peerConnectionFoundMap.get(senderClientId);
             if (peer != null){
                 final boolean addIce = peer.addIceCandidate(iceCandidate);
                 Log.d(TAG, "Added ice candidate " + iceCandidate + " " + (addIce ? "Successfully" : "Failed"));
@@ -399,8 +478,10 @@ public class WebRtcActivity extends AppCompatActivity {
         Thread.setDefaultUncaughtExceptionHandler(null);
         printStatsExecutor.shutdownNow();
 
-        audioManager.setMode(originalAudioMode);
-        audioManager.setSpeakerphoneOn(originalSpeakerphoneOn);
+        if (audioManager != null) {
+            audioManager.setMode(originalAudioMode);
+            audioManager.setSpeakerphoneOn(originalSpeakerphoneOn);
+        }
 
         if (rootEglBase != null) {
             rootEglBase.release();
@@ -452,6 +533,11 @@ public class WebRtcActivity extends AppCompatActivity {
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
 
+        // Skip WebRTC initialization if codec validation failed
+        if (codecValidationFailed) {
+            return;
+        }
+
         // Start websocket after adding local audio/video tracks
         initWsConnection();
 
@@ -486,6 +572,7 @@ public class WebRtcActivity extends AppCompatActivity {
         }
         master = intent.getBooleanExtra(KEY_IS_MASTER, true);
         isAudioSent = intent.getBooleanExtra(KEY_SEND_AUDIO, false);
+        isVideoSent = intent.getBooleanExtra(KEY_SEND_VIDEO, false);
         ArrayList<String> mUserNames = intent.getStringArrayListExtra(KEY_ICE_SERVER_USER_NAME);
         ArrayList<String> mPasswords = intent.getStringArrayListExtra(KEY_ICE_SERVER_PASSWORD);
         ArrayList<List<String>> mUrisList = (ArrayList<List<String>>) intent.getSerializableExtra(KEY_ICE_SERVER_URI);
@@ -511,7 +598,6 @@ public class WebRtcActivity extends AppCompatActivity {
                             .setUsername(mUserNames.get(i))
                             .setPassword(mPasswords.get(i))
                             .createIceServer();
-
                     Log.d(TAG, "IceServer details (TURN) = " + iceServer.toString());
                     peerIceServers.add(iceServer);
                 }
@@ -524,18 +610,25 @@ public class WebRtcActivity extends AppCompatActivity {
                 .InitializationOptions
                 .builder(this)
                 .createInitializationOptions());
+                
+        // Codec validation after WebRTC initialization but before UI setup
+        if (checkCodecSupport()) {
+            return; // Codec not supported, dialog shown, don't proceed
+        }
 
         final VideoDecoderFactory vdf = new DefaultVideoDecoderFactory(rootEglBase.getEglBaseContext());
         Log.d(TAG, "Available decoders on this device:");
         for (final VideoCodecInfo videoCodecInfo : vdf.getSupportedCodecs()) {
             Log.d(TAG, videoCodecInfo.name);
         }
+        
         final VideoEncoderFactory vef = new DefaultVideoEncoderFactory(rootEglBase.getEglBaseContext(),
                 ENABLE_INTEL_VP8_ENCODER, ENABLE_H264_HIGH_PROFILE);
         Log.d(TAG, "Available encoders on this device:");
         for (final VideoCodecInfo videoCodecInfo : vef.getSupportedCodecs()) {
             Log.d(TAG, videoCodecInfo.name);
         }
+        
         peerConnectionFactory =
                 PeerConnectionFactory.builder()
                         .setVideoDecoderFactory(vdf)
@@ -547,20 +640,33 @@ public class WebRtcActivity extends AppCompatActivity {
         // Enable Google WebRTC debug logs
         Logging.enableLogToDebugOutput(Logging.Severity.LS_INFO);
 
-        videoCapturer = createVideoCapturer();
+        // Check if we should create video track based on user preference and session type
+        boolean shouldCreateVideo = isVideoSent && !isStorageViewer();
+        
+        if (shouldCreateVideo) {
+            videoCapturer = createVideoCapturer();
 
-        // Local video view
-        localView = findViewById(R.id.local_view);
-        localView.init(rootEglBase.getEglBaseContext(), null);
-        localView.setEnableHardwareScaler(true);
+            // Local video view
+            localView = findViewById(R.id.local_view);
+            localView.init(rootEglBase.getEglBaseContext(), null);
+            localView.setEnableHardwareScaler(true);
 
+            videoSource = peerConnectionFactory.createVideoSource(false);
+            SurfaceTextureHelper surfaceTextureHelper = SurfaceTextureHelper.create(Thread.currentThread().getName(), rootEglBase.getEglBaseContext());
+            videoCapturer.initialize(surfaceTextureHelper, this.getApplicationContext(), videoSource.getCapturerObserver());
 
-        videoSource = peerConnectionFactory.createVideoSource(false);
-        SurfaceTextureHelper surfaceTextureHelper = SurfaceTextureHelper.create(Thread.currentThread().getName(), rootEglBase.getEglBaseContext());
-        videoCapturer.initialize(surfaceTextureHelper, this.getApplicationContext(), videoSource.getCapturerObserver());
-
-        localVideoTrack = peerConnectionFactory.createVideoTrack(VideoTrackID, videoSource);
-        localVideoTrack.addSink(localView);
+            localVideoTrack = peerConnectionFactory.createVideoTrack(VideoTrackID, videoSource);
+            localVideoTrack.addSink(localView);
+            
+            // Start capturing video
+            videoCapturer.startCapture(VIDEO_SIZE_WIDTH, VIDEO_SIZE_HEIGHT, VIDEO_FPS);
+            localVideoTrack.setEnabled(true);
+        } else {
+            Log.d(TAG, "Storage session viewer - skipping video track creation");
+            // Still initialize local view for UI consistency
+            localView = findViewById(R.id.local_view);
+            localView.init(rootEglBase.getEglBaseContext(), null);
+        }
 
         if (isAudioSent) {
             AudioSource audioSource = peerConnectionFactory.createAudioSource(new MediaConstraints());
@@ -572,9 +678,7 @@ public class WebRtcActivity extends AppCompatActivity {
         originalAudioMode = audioManager.getMode();
         originalSpeakerphoneOn = audioManager.isSpeakerphoneOn();
 
-        // Start capturing video
-        videoCapturer.startCapture(VIDEO_SIZE_WIDTH, VIDEO_SIZE_HEIGHT, VIDEO_FPS);
-        localVideoTrack.setEnabled(true);
+
 
         remoteView = findViewById(R.id.remote_view);
         remoteView.init(rootEglBase.getEglBaseContext(), null);
@@ -635,9 +739,7 @@ public class WebRtcActivity extends AppCompatActivity {
 
             @Override
             public void onIceCandidate(final IceCandidate iceCandidate) {
-
                 super.onIceCandidate(iceCandidate);
-
                 final Message message = createIceCandidateMessage(iceCandidate);
                 Log.d(TAG, "Sending IceCandidate to remote peer " + iceCandidate);
                 client.sendIceCandidate(message);  /* Send to Peer */
@@ -647,9 +749,7 @@ public class WebRtcActivity extends AppCompatActivity {
             public void onAddStream(final MediaStream mediaStream) {
 
                 super.onAddStream(mediaStream);
-
                 Log.d(TAG, "Adding remote video stream (and audio) to the view");
-
                 addRemoteStreamToVideoView(mediaStream);
             }
 
@@ -662,6 +762,8 @@ public class WebRtcActivity extends AppCompatActivity {
                     runOnUiThread(() -> Toast.makeText(getApplicationContext(), "Connected to peer!", Toast.LENGTH_LONG).show());
                 }
             }
+
+
 
             @Override
             public void onDataChannel(final DataChannel dataChannel) {
@@ -749,15 +851,16 @@ public class WebRtcActivity extends AppCompatActivity {
 
         final MediaStream stream = peerConnectionFactory.createLocalMediaStream(LOCAL_MEDIA_STREAM_LABEL);
 
-        if (!stream.addTrack(localVideoTrack)) {
-            Log.e(TAG, "Add video track failed");
+        // Only add video track if it was created (not for storage session viewers)
+        if (localVideoTrack != null) {
+            if (!stream.addTrack(localVideoTrack)) {
+                Log.e(TAG, "Add video track failed");
+            }
+            localPeer.addTrack(stream.videoTracks.get(0), Collections.singletonList(stream.getId()));
         }
-
-        localPeer.addTrack(stream.videoTracks.get(0), Collections.singletonList(stream.getId()));
 
         if (isAudioSent) {
             if (!stream.addTrack(localAudioTrack)) {
-
                 Log.e(TAG, "Add audio track failed");
             }
 
@@ -803,16 +906,14 @@ public class WebRtcActivity extends AppCompatActivity {
         });
     }
 
-    // when mobile sdk is viewer
+    // when mobile sdk is viewer (direct connection only)
     private void createSdpOffer() {
-
         MediaConstraints sdpMediaConstraints = new MediaConstraints();
 
         sdpMediaConstraints.mandatory.add(new MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"));
         sdpMediaConstraints.mandatory.add(new MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"));
 
         if (localPeer == null) {
-
             createLocalPeerConnection();
         }
 
@@ -820,7 +921,6 @@ public class WebRtcActivity extends AppCompatActivity {
 
             @Override
             public void onCreateSuccess(SessionDescription sessionDescription) {
-
                 super.onCreateSuccess(sessionDescription);
 
                 localPeer.setLocalDescription(new KinesisVideoSdpObserver(), sessionDescription);
@@ -833,13 +933,13 @@ public class WebRtcActivity extends AppCompatActivity {
                     notifySignalingConnectionFailed();
                 }
             }
+
         }, sdpMediaConstraints);
     }
 
 
-    // when local is set to be the master
+    // when local is set to be the master or storage session viewer
     private void createSdpAnswer() {
-
         final MediaConstraints sdpMediaConstraints = new MediaConstraints();
 
         sdpMediaConstraints.mandatory.add(new MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"));
@@ -851,7 +951,9 @@ public class WebRtcActivity extends AppCompatActivity {
             public void onCreateSuccess(final SessionDescription sessionDescription) {
                 Log.d(TAG, "Creating answer: success");
                 super.onCreateSuccess(sessionDescription);
+                
                 localPeer.setLocalDescription(new KinesisVideoSdpObserver(), sessionDescription);
+                
                 final Message answer = Message.createAnswerMessage(sessionDescription, master, recipientClientId);
                 client.sendSdpAnswer(answer);
 
@@ -862,7 +964,6 @@ public class WebRtcActivity extends AppCompatActivity {
             @Override
             public void onCreateFailure(final String error) {
                 super.onCreateFailure(error);
-
                 // Device is unable to support the requested media format
                 if (error.contains("ERROR_CONTENT")) {
                     Log.e(TAG, "No supported codec is present in the offer!");

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/activity/WebRtcActivity.java
@@ -299,6 +299,17 @@ public class WebRtcActivity extends AppCompatActivity {
                         joinStorageSession(storageClient);
                     } catch (Exception ex) {
                         Log.e(TAG, "Error sending join storage session request!", ex);
+                        runOnUiThread(() -> {
+                            new AlertDialog.Builder(WebRtcActivity.this)
+                                        .setTitle("Storage session Error")
+                                        .setMessage("Error sending join storage session request: " + ex.getMessage())
+                                        .setPositiveButton("OK", (dialog, which) -> {
+                                            dialog.dismiss();
+                                            finish();
+                                        })
+                                        .show();
+                        });
+                        return; //prevent any code after from executing                           
                     }
                 }).start();
             }

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -1,6 +1,7 @@
 package com.amazonaws.kinesisvideo.demoapp.fragment;
 
 import android.Manifest;
+import com.amazonaws.kinesisvideo.demoapp.BuildConfig;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
@@ -313,6 +314,15 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         awsKinesisVideoClient.setRegion(Region.getRegion(region));
         awsKinesisVideoClient.setSignerRegionOverride(region);
         awsKinesisVideoClient.setServiceNameIntern("kinesisvideo");
+        try {
+            String customEndpoint = BuildConfig.CONTROL_PLANE_URI;
+            if (customEndpoint != null && !customEndpoint.isEmpty() && !"null".equals(customEndpoint)) {
+                awsKinesisVideoClient.setEndpoint(customEndpoint);
+            }
+        } catch (Exception e) {
+            // CONTROL_PLANE_URI not defined in .env
+        }
+        
         return awsKinesisVideoClient;
     }
 

--- a/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
+++ b/app/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamWebRtcConfigurationFragment.java
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
+import android.content.Context;
 
 import com.amazonaws.kinesisvideo.demoapp.KinesisVideoWebRtcDemoApp;
 import com.amazonaws.kinesisvideo.demoapp.R;
@@ -48,6 +49,7 @@ import com.amazonaws.services.kinesisvideosignaling.model.GetIceServerConfigRequ
 import com.amazonaws.services.kinesisvideosignaling.model.GetIceServerConfigResult;
 import com.amazonaws.services.kinesisvideosignaling.model.IceServer;
 
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +72,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
     public static final String KEY_ICE_SERVER_URI = "iceServerUri";
     public static final String KEY_CAMERA_FRONT_FACING = "cameraFrontFacing";
 
-    private static final String KEY_SEND_VIDEO = "sendVideo";
+    public static final String KEY_SEND_VIDEO = "sendVideo";
     public static final String KEY_SEND_AUDIO = "sendAudio";
 
     private static final String[] WEBRTC_OPTIONS = {
@@ -143,16 +145,7 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
                     final CheckedTextView ctv = v.findViewById(android.R.id.text1);
                     ctv.setText(WEBRTC_OPTIONS[position]);
 
-                    // Send video is enabled by default and cannot uncheck
-                    if (position == 0) {
-                        ctv.setEnabled(false);
-                        ctv.setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View view) {
-                                ctv.setChecked(true);
-                            }
-                        });
-                    }
+                    // Send video is now optional
                     return v;
                 }
 
@@ -181,6 +174,8 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
         }
     }
 
+
+
     private View.OnClickListener startMasterActivityWhenClicked() {
         return new View.OnClickListener() {
             @Override
@@ -191,10 +186,10 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
     }
 
     private void startMasterActivity() {
-
+        final SparseBooleanArray checked = mOptions.getCheckedItemPositions();
+        
         if (mIngestMedia.isChecked()) {
-            // Check that the "Send Audio" and "Send Video" boxes are enabled.
-            final SparseBooleanArray checked = mOptions.getCheckedItemPositions();
+            // Check that both "Send Audio" and "Send Video" boxes are enabled for ingest media
             for (int i = 0; i < mOptions.getCount(); i++) {
                 if (!checked.get(i)) {
                     new AlertDialog.Builder(getActivity())
@@ -231,6 +226,19 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
     }
 
     private void startViewerActivity() {
+        Log.i(TAG, "Start Viewer button clicked - beginning viewer activity setup");
+        final SparseBooleanArray checked = mOptions.getCheckedItemPositions();
+        
+//        Check if Ingest Media is checked with Send Video
+        if (mIngestMedia.isChecked() && checked.get(0)) {
+            new AlertDialog.Builder(getActivity())
+                    .setPositiveButton("OK", null)
+                    .setMessage("Multi-viewer participant is allowed to send only audio; please deselect video for multiviewer option")
+                    .create()
+                    .show();
+            return;
+        }
+        
         if (!updateSignalingChannelInfo(mRegion.getText().toString(),
                 mChannelName.getText().toString(),
                 ChannelRole.VIEWER)) {
@@ -341,6 +349,17 @@ public class StreamWebRtcConfigurationFragment extends Fragment {
 
         if (errorMessage != null) {
             Log.e(TAG, "updateSignalingChannelInfo() encountered an error: " + errorMessage);
+            // Show error to user for debugging
+            final String finalErrorMessage = errorMessage;
+            if (getActivity() != null) {
+                getActivity().runOnUiThread(() -> {
+                    new AlertDialog.Builder(getContext())
+                            .setTitle("Connection Error")
+                            .setMessage(finalErrorMessage)
+                            .setPositiveButton("OK", null)
+                            .show();
+                });
+            }
         }
         return errorMessage == null;
     }

--- a/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
+++ b/app/src/main/res/layout/fragment_stream_webrtc_configuration.xml
@@ -92,7 +92,7 @@
         <CheckBox
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Ingest media (master only)"
+            android:text="Ingest media"
             android:layoutDirection="rtl"
             android:id="@+id/ingest_media"
             android:layout_margin="16dp"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:* 

**What was changed?**

* Multi-Viewer WebRTC storage (Ingestion): Implemented viewer participant WebRTC connection establishment with the KVS WebRTC storage session
* Environment Configuration: Added .env file support for directly using AWS credentials and control plane endpoints
* H.264 Codec Validation: Added codec compatibility checks for storage session mode
* Enhanced Error Handling: Implemented error dialogs for storage session join failures
* UI Improvements
    * data channel text box is removed when using WebRTC Storage
    * local video view is removed when using WebRTC Storage viewer
* AWS SDK Upgrade: Updated AWS Android SDK from 2.75.0 to 2.81.1 to address the 16 KB Google Play compatibility issue [https://developer.android.com/guide/practices/page-sizes]

**Why was it changed?**

* Multi-Viewer Feature Launch: enables customer to view their camera using WebRTC from multiple viewing devices (mobile/browser); max concurrent sesison is limited to 3
* Developer Experience: Simplified development workflow by eliminating Cognito setup requirements through .env configuration
* Production Readiness: Enhanced codec validation and error handling match with the currently supported formats

**How was it changed?**

* Removed master-only WebRTC storage from Android (allows customers to use device as master and viewer for WebRTC Storage)
* Added JoinStorageSessionAsViewer ([https://docs.aws.amazon.com/kinesisvideostreams](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_webrtc_JoinStorageSessionAsViewer.html)[/latest/dg/API_webrtc_JoinStorageSessionAsViewer.html](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_webrtc_JoinStorageSessionAsViewer.html)) call
* Added UI validation preventing storage session viewers from using video with ingest media (audio-only restriction)
* Modified build.gradle to parse .env file and generate compile-time BuildConfig constants for AWS credentials
* Added custom credentials provider(for testing only) and disabled logout for .env credential users
* Implemented H.264 encoder/decoder validation with user-friendly error dialogs
* Enhanced storage session error handling with pop up notifications
* Decided UI element's visibility based on webrtc ingestion configuration

**What testing was done for the changes?**

* P2P Compatibility: Verified mobile master and viewer functionality remains intact in peer-to-peer mode
* Multi-Viewer Storage: Tested Android master with WebRTC storage (audio+video), multiple Android viewers with audio-only ingestion, mixed Android/JS scenarios, dynamic viewer connection/disconnection, and verified media recording and playback from storage streams
* Cross-SDK Compatibility: Confirmed Android SDK establishes connections successfully with KVS WebRTC SDKs (iOS, C, JS)
* UI Transitions: Verified seamless UI transitions between ingestion mode and peer-to-peer mode
* Error Handling: Tested error handling scenarios and dialog responses for various failure cases
* Codec Validation: Confirmed proper H.264 encoder/decoder detection and error messaging


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
